### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     "codecompanion-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753907254,
-        "narHash": "sha256-KkxtMAspKSaGLDSvABIKE7X28xa7Q8tQoP+tfWY+kUI=",
+        "lastModified": 1754068529,
+        "narHash": "sha256-ZHEceu2dxmUiHPzK7maXnEtVijDGthFIYtpiOY4h7DA=",
         "owner": "olimorris",
         "repo": "codecompanion.nvim",
-        "rev": "3d4d85f03acc3a31ea2ec9bd34db5194ed7696ff",
+        "rev": "6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753286973,
-        "narHash": "sha256-w70rSwYdjMRGCLYcwIoA4cvl6JcGQYHngCBJvRq+SXg=",
+        "lastModified": 1754037237,
+        "narHash": "sha256-JhTqTGQfIryJ7MElcOGOfb48uaNDnd9RM9Fl1Fs4QV0=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "3d5bced1b9ae69fa3f9b1942e28af5dbc537f946",
+        "rev": "de10d8414235b0a8cabfeba60d07c24304e71f5c",
         "type": "github"
       },
       "original": {
@@ -478,11 +478,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1753958863,
-        "narHash": "sha256-wMBPL9P3EU4yh4LwZae2N6wTywHojAmWNZSG2dNBejk=",
+        "lastModified": 1754050710,
+        "narHash": "sha256-zGGx7XFSJd1mRIrUrDbjKGXDjfk/aPRToDbLrshLbUU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "e4f3f820bfaed3a742584476c0bcc3eab2a55929",
+        "rev": "84d2911ae6b97e160ed8de8ece7bd1068c2bf686",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1753840437,
-        "narHash": "sha256-ybxx34SL/q5VkY80rykPcDSuG2KGRvggC1TaCcAmqIA=",
+        "lastModified": 1753992225,
+        "narHash": "sha256-QUlWhBgDm9No+RkI33faSqsSZNU/QhZjMOP333FjN38=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b79ff967ac91dce40f3598ea407c5ccaa2929250",
+        "rev": "c3a4d125296caaf15ff424e7609e731a8b4d37e7",
         "type": "github"
       },
       "original": {
@@ -525,11 +525,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753844155,
-        "narHash": "sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc=",
+        "lastModified": 1754060105,
+        "narHash": "sha256-di5L6e5Iiv+oegS07j9h23FdqEpXn0ZQqMlDOEMw1EY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e44b8dc0882d66e2627a8ff252b04a22f4a629fd",
+        "rev": "e7eabdc701d7dbb810fd91a97ec358caa4c1fc50",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1753837371,
-        "narHash": "sha256-IsdjkpE+T5irvmH5fam5EmsCpzwxSEiXV3r2iXsOVT0=",
+        "lastModified": 1754018889,
+        "narHash": "sha256-0iNMc5mOygNUgsX9+/V88bIVNheSJxxsIWojsOgD/Jg=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "3db16ceeea947517f0dc1404c24dcb5ab0c91d26",
+        "rev": "d0dbf489a8810672fa9a61f4a86e5cf89214b772",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/3d4d85f03acc3a31ea2ec9bd34db5194ed7696ff?narHash=sha256-KkxtMAspKSaGLDSvABIKE7X28xa7Q8tQoP%2BtfWY%2BkUI%3D' (2025-07-30)
  → 'github:olimorris/codecompanion.nvim/6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a?narHash=sha256-ZHEceu2dxmUiHPzK7maXnEtVijDGthFIYtpiOY4h7DA%3D' (2025-08-01)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/3d5bced1b9ae69fa3f9b1942e28af5dbc537f946?narHash=sha256-w70rSwYdjMRGCLYcwIoA4cvl6JcGQYHngCBJvRq%2BSXg%3D' (2025-07-23)
  → 'github:L3MON4D3/LuaSnip/de10d8414235b0a8cabfeba60d07c24304e71f5c?narHash=sha256-JhTqTGQfIryJ7MElcOGOfb48uaNDnd9RM9Fl1Fs4QV0%3D' (2025-08-01)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/e4f3f820bfaed3a742584476c0bcc3eab2a55929?narHash=sha256-wMBPL9P3EU4yh4LwZae2N6wTywHojAmWNZSG2dNBejk%3D' (2025-07-31)
  → 'github:nix-community/neovim-nightly-overlay/84d2911ae6b97e160ed8de8ece7bd1068c2bf686?narHash=sha256-zGGx7XFSJd1mRIrUrDbjKGXDjfk/aPRToDbLrshLbUU%3D' (2025-08-01)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/b79ff967ac91dce40f3598ea407c5ccaa2929250?narHash=sha256-ybxx34SL/q5VkY80rykPcDSuG2KGRvggC1TaCcAmqIA%3D' (2025-07-30)
  → 'github:neovim/neovim/c3a4d125296caaf15ff424e7609e731a8b4d37e7?narHash=sha256-QUlWhBgDm9No%2BRkI33faSqsSZNU/QhZjMOP333FjN38%3D' (2025-07-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e44b8dc0882d66e2627a8ff252b04a22f4a629fd?narHash=sha256-w81jpZeM3AtYlTKIhT05p3IqvJRIHZPyp0Acgb6hXWc%3D' (2025-07-30)
  → 'github:nixos/nixpkgs/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50?narHash=sha256-di5L6e5Iiv%2BoegS07j9h23FdqEpXn0ZQqMlDOEMw1EY%3D' (2025-08-01)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/3db16ceeea947517f0dc1404c24dcb5ab0c91d26?narHash=sha256-IsdjkpE%2BT5irvmH5fam5EmsCpzwxSEiXV3r2iXsOVT0%3D' (2025-07-30)
  → 'github:neovim/nvim-lspconfig/d0dbf489a8810672fa9a61f4a86e5cf89214b772?narHash=sha256-0iNMc5mOygNUgsX9%2B/V88bIVNheSJxxsIWojsOgD/Jg%3D' (2025-08-01)

```

</p></details>

 - Updated input [`codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [`3d4d85f0` ➡️ `6b8480ee`](https://github.com/olimorris/codecompanion.nvim/compare/3d4d85f03acc3a31ea2ec9bd34db5194ed7696ff...6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a) <sub>(2025-07-30 to 2025-08-01)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`e4f3f820` ➡️ `84d2911a`](https://github.com/nix-community/neovim-nightly-overlay/compare/e4f3f820bfaed3a742584476c0bcc3eab2a55929...84d2911ae6b97e160ed8de8ece7bd1068c2bf686) <sub>(2025-07-31 to 2025-08-01)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`3d5bced1` ➡️ `de10d841`](https://github.com/L3MON4D3/LuaSnip/compare/3d5bced1b9ae69fa3f9b1942e28af5dbc537f946...de10d8414235b0a8cabfeba60d07c24304e71f5c) <sub>(2025-07-23 to 2025-08-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`3db16cee` ➡️ `d0dbf489`](https://github.com/neovim/nvim-lspconfig/compare/3db16ceeea947517f0dc1404c24dcb5ab0c91d26...d0dbf489a8810672fa9a61f4a86e5cf89214b772) <sub>(2025-07-30 to 2025-08-01)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e44b8dc0` ➡️ `e7eabdc7`](https://github.com/nixos/nixpkgs/compare/e44b8dc0882d66e2627a8ff252b04a22f4a629fd...e7eabdc701d7dbb810fd91a97ec358caa4c1fc50) <sub>(2025-07-30 to 2025-08-01)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`b79ff967` ➡️ `c3a4d125`](https://github.com/neovim/neovim/compare/b79ff967ac91dce40f3598ea407c5ccaa2929250...c3a4d125296caaf15ff424e7609e731a8b4d37e7) <sub>(2025-07-30 to 2025-07-31)</sub>