### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     "codecompanion-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754068529,
-        "narHash": "sha256-ZHEceu2dxmUiHPzK7maXnEtVijDGthFIYtpiOY4h7DA=",
+        "lastModified": 1754561654,
+        "narHash": "sha256-zY9uWB11mr/XDAw/l4HLAy3ZHaIhUiYlzUFbiKVFSvg=",
         "owner": "olimorris",
         "repo": "codecompanion.nvim",
-        "rev": "6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a",
+        "rev": "19d665a9b13c0b05652c359c4302465b8b2543be",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -280,11 +280,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -340,11 +340,11 @@
     "hop-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1740592943,
-        "narHash": "sha256-gHRKkqAMrQmpPHEWGETj3KG0NqwCnlTT8z/cNmug/Xc=",
+        "lastModified": 1754504110,
+        "narHash": "sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA=",
         "owner": "smoka7",
         "repo": "hop.nvim",
-        "rev": "9c6a1dd9afb53a112b128877ccd583a1faa0b8b6",
+        "rev": "2254e0b3c8054b9ee661c9be3cb201d4b3384d8e",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753804266,
-        "narHash": "sha256-GCqNLBlKlTnuYmXjR8bZ4TNunEhidij7rTURqLDX8v4=",
+        "lastModified": 1754256310,
+        "narHash": "sha256-02sk11tKvsT+R+UMGFmYGehD+sQuBUFiij0T+F/VtOU=",
         "owner": "dkuettel",
         "repo": "lavish-layouts.nvim",
-        "rev": "dc414d1305e490a38bcfdb7ffae555910cf66217",
+        "rev": "6862bce269f99518d93264d8100a91b1e2d93c67",
         "type": "github"
       },
       "original": {
@@ -478,11 +478,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1754050710,
-        "narHash": "sha256-zGGx7XFSJd1mRIrUrDbjKGXDjfk/aPRToDbLrshLbUU=",
+        "lastModified": 1754641381,
+        "narHash": "sha256-eMoujl/X1lbdjRbC/HHCpZmUb5tqTAYSL1hocy+o7nc=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "84d2911ae6b97e160ed8de8ece7bd1068c2bf686",
+        "rev": "83aaf3085f808dec9ea1b5d16b216875a8081b37",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1753992225,
-        "narHash": "sha256-QUlWhBgDm9No+RkI33faSqsSZNU/QhZjMOP333FjN38=",
+        "lastModified": 1754610154,
+        "narHash": "sha256-ORfF40X4BGiFxnLNQbdsQbUTW4TkUHfPqyZWHaYL5NE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "c3a4d125296caaf15ff424e7609e731a8b4d37e7",
+        "rev": "038eb01b41b66379f75164507571497929f8847c",
         "type": "github"
       },
       "original": {
@@ -525,11 +525,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754060105,
-        "narHash": "sha256-di5L6e5Iiv+oegS07j9h23FdqEpXn0ZQqMlDOEMw1EY=",
+        "lastModified": 1754640348,
+        "narHash": "sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7eabdc701d7dbb810fd91a97ec358caa4c1fc50",
+        "rev": "a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1754018889,
-        "narHash": "sha256-0iNMc5mOygNUgsX9+/V88bIVNheSJxxsIWojsOgD/Jg=",
+        "lastModified": 1754445803,
+        "narHash": "sha256-FJGFwDeA0HxEEawnytdH663aFdf7lKKTwDZw9XX3Jxg=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "d0dbf489a8810672fa9a61f4a86e5cf89214b772",
+        "rev": "9141be4c1332afc83bdf1b0278dbb030f75ff8e3",
         "type": "github"
       },
       "original": {
@@ -795,11 +795,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753772294,
-        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {
@@ -836,11 +836,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753653538,
-        "narHash": "sha256-1IwOcdIUJuh7YC2YTw0VnGI2UIg7F/ipxLLfQdPzjFQ=",
+        "lastModified": 1754086681,
+        "narHash": "sha256-OzLLsrDaAHcNqasrHiL0hRNH9XZtCyoKrUFeSt/Iol8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "4a8369f4c78ef6f6f895f0cec349e48f74330574",
+        "rev": "3362099de3368aa620a8105b19ed04c2053e38c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a?narHash=sha256-ZHEceu2dxmUiHPzK7maXnEtVijDGthFIYtpiOY4h7DA%3D' (2025-08-01)
  → 'github:olimorris/codecompanion.nvim/19d665a9b13c0b05652c359c4302465b8b2543be?narHash=sha256-zY9uWB11mr/XDAw/l4HLAy3ZHaIhUiYlzUFbiKVFSvg%3D' (2025-08-07)
• Updated input 'hop-nvim':
    'github:smoka7/hop.nvim/9c6a1dd9afb53a112b128877ccd583a1faa0b8b6?narHash=sha256-gHRKkqAMrQmpPHEWGETj3KG0NqwCnlTT8z/cNmug/Xc%3D' (2025-02-26)
  → 'github:smoka7/hop.nvim/2254e0b3c8054b9ee661c9be3cb201d4b3384d8e?narHash=sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA%3D' (2025-08-06)
• Updated input 'lavish-layouts-nvim':
    'github:dkuettel/lavish-layouts.nvim/dc414d1305e490a38bcfdb7ffae555910cf66217?narHash=sha256-GCqNLBlKlTnuYmXjR8bZ4TNunEhidij7rTURqLDX8v4%3D' (2025-07-29)
  → 'github:dkuettel/lavish-layouts.nvim/6862bce269f99518d93264d8100a91b1e2d93c67?narHash=sha256-02sk11tKvsT%2BR%2BUMGFmYGehD%2BsQuBUFiij0T%2BF/VtOU%3D' (2025-08-03)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/84d2911ae6b97e160ed8de8ece7bd1068c2bf686?narHash=sha256-zGGx7XFSJd1mRIrUrDbjKGXDjfk/aPRToDbLrshLbUU%3D' (2025-08-01)
  → 'github:nix-community/neovim-nightly-overlay/83aaf3085f808dec9ea1b5d16b216875a8081b37?narHash=sha256-eMoujl/X1lbdjRbC/HHCpZmUb5tqTAYSL1hocy%2Bo7nc%3D' (2025-08-08)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/644e0fc48951a860279da645ba77fe4a6e814c5e?narHash=sha256-TVcTNvOeWWk1DXljFxVRp%2BE0tzG1LhrVjOGGoMHuXio%3D' (2025-07-21)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/16ec914f6fb6f599ce988427d9d94efddf25fe6d?narHash=sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg%3D' (2025-06-24)
  → 'github:cachix/git-hooks.nix/9c52372878df6911f9afc1e2a1391f55e4dfc864?narHash=sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef%2B6fRcofA%3D' (2025-08-05)
• Updated input 'neovim-nightly-overlay/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/c3a4d125296caaf15ff424e7609e731a8b4d37e7?narHash=sha256-QUlWhBgDm9No%2BRkI33faSqsSZNU/QhZjMOP333FjN38%3D' (2025-07-31)
  → 'github:neovim/neovim/038eb01b41b66379f75164507571497929f8847c?narHash=sha256-ORfF40X4BGiFxnLNQbdsQbUTW4TkUHfPqyZWHaYL5NE%3D' (2025-08-07)
• Updated input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/6b9214fffbcf3f1e608efa15044431651635ca83?narHash=sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE%3D' (2025-07-29)
  → 'github:numtide/treefmt-nix/1298185c05a56bff66383a20be0b41a307f52228?narHash=sha256-B%2B3g9%2B76KlGe34Yk9za8AF3RL%2BlnbHXkLiVHLjYVOAc%3D' (2025-08-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50?narHash=sha256-di5L6e5Iiv%2BoegS07j9h23FdqEpXn0ZQqMlDOEMw1EY%3D' (2025-08-01)
  → 'github:nixos/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1?narHash=sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E%3D' (2025-08-08)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/d0dbf489a8810672fa9a61f4a86e5cf89214b772?narHash=sha256-0iNMc5mOygNUgsX9%2B/V88bIVNheSJxxsIWojsOgD/Jg%3D' (2025-08-01)
  → 'github:neovim/nvim-lspconfig/9141be4c1332afc83bdf1b0278dbb030f75ff8e3?narHash=sha256-FJGFwDeA0HxEEawnytdH663aFdf7lKKTwDZw9XX3Jxg%3D' (2025-08-06)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/4a8369f4c78ef6f6f895f0cec349e48f74330574?narHash=sha256-1IwOcdIUJuh7YC2YTw0VnGI2UIg7F/ipxLLfQdPzjFQ%3D' (2025-07-27)
  → 'github:nvim-tree/nvim-web-devicons/3362099de3368aa620a8105b19ed04c2053e38c0?narHash=sha256-OzLLsrDaAHcNqasrHiL0hRNH9XZtCyoKrUFeSt/Iol8%3D' (2025-08-01)

```

</p></details>

 - Updated input [`neovim-nightly-overlay/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `9100a0f4`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...9100a0f413b0c601e0533d1d94ffd501ce2e7885) <sub>(2023-10-04 to 2025-05-12)</sub>
 - Updated input [`codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [`6b8480ee` ➡️ `19d665a9`](https://github.com/olimorris/codecompanion.nvim/compare/6b8480ee5ddb9294f3fe21f526d36dfa4d15f06a...19d665a9b13c0b05652c359c4302465b8b2543be) <sub>(2025-08-01 to 2025-08-07)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`84d2911a` ➡️ `83aaf308`](https://github.com/nix-community/neovim-nightly-overlay/compare/84d2911ae6b97e160ed8de8ece7bd1068c2bf686...83aaf3085f808dec9ea1b5d16b216875a8081b37) <sub>(2025-08-01 to 2025-08-08)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`d0dbf489` ➡️ `9141be4c`](https://github.com/neovim/nvim-lspconfig/compare/d0dbf489a8810672fa9a61f4a86e5cf89214b772...9141be4c1332afc83bdf1b0278dbb030f75ff8e3) <sub>(2025-08-01 to 2025-08-06)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e7eabdc7` ➡️ `a3f3e3f2`](https://github.com/nixos/nixpkgs/compare/e7eabdc701d7dbb810fd91a97ec358caa4c1fc50...a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1) <sub>(2025-08-01 to 2025-08-08)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`16ec914f` ➡️ `9c523728`](https://github.com/cachix/git-hooks.nix/compare/16ec914f6fb6f599ce988427d9d94efddf25fe6d...9c52372878df6911f9afc1e2a1391f55e4dfc864) <sub>(2025-06-24 to 2025-08-05)</sub>
 - Updated input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`6b9214ff` ➡️ `1298185c`](https://github.com/numtide/treefmt-nix/compare/6b9214fffbcf3f1e608efa15044431651635ca83...1298185c05a56bff66383a20be0b41a307f52228) <sub>(2025-07-29 to 2025-08-06)</sub>
 - Updated input [`lavish-layouts-nvim`](https://github.com/dkuettel/lavish-layouts.nvim): [`dc414d13` ➡️ `6862bce2`](https://github.com/dkuettel/lavish-layouts.nvim/compare/dc414d1305e490a38bcfdb7ffae555910cf66217...6862bce269f99518d93264d8100a91b1e2d93c67) <sub>(2025-07-29 to 2025-08-03)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`4a8369f4` ➡️ `3362099d`](https://github.com/nvim-tree/nvim-web-devicons/compare/4a8369f4c78ef6f6f895f0cec349e48f74330574...3362099de3368aa620a8105b19ed04c2053e38c0) <sub>(2025-07-27 to 2025-08-01)</sub>
 - Updated input [`hop-nvim`](https://github.com/smoka7/hop.nvim): [`9c6a1dd9` ➡️ `2254e0b3`](https://github.com/smoka7/hop.nvim/compare/9c6a1dd9afb53a112b128877ccd583a1faa0b8b6...2254e0b3c8054b9ee661c9be3cb201d4b3384d8e) <sub>(2025-02-26 to 2025-08-06)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`c3a4d125` ➡️ `038eb01b`](https://github.com/neovim/neovim/compare/c3a4d125296caaf15ff424e7609e731a8b4d37e7...038eb01b41b66379f75164507571497929f8847c) <sub>(2025-07-31 to 2025-08-07)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`644e0fc4` ➡️ `af66ad14`](https://github.com/hercules-ci/flake-parts/compare/644e0fc48951a860279da645ba77fe4a6e814c5e...af66ad14b28a127c5c0f3bbb298218fc63528a18) <sub>(2025-07-21 to 2025-08-06)</sub>