### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,22 @@
         "type": "github"
       }
     },
+    "auspicious-autosave-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1751198988,
+        "narHash": "sha256-130aVlInsFwnw8LD5vXVRUp6b3VCzWOzVt640T/+Drs=",
+        "owner": "dkuettel",
+        "repo": "auspicious-autosave.nvim",
+        "rev": "a19edaf5619a1499c170b3479f9970761fa64f41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dkuettel",
+        "repo": "auspicious-autosave.nvim",
+        "type": "github"
+      }
+    },
     "cmp-buffer-nvim": {
       "flake": false,
       "locked": {
@@ -96,6 +112,22 @@
         "type": "github"
       }
     },
+    "cmp-buffer-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743497185,
+        "narHash": "sha256-dG4U7MtnXThoa/PD+qFtCt76MQ14V1wX8GMYcvxEnbM=",
+        "owner": "hrsh7th",
+        "repo": "cmp-buffer",
+        "rev": "b74fab3656eea9de20a9b8116afa3cfc4ec09657",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-buffer",
+        "type": "github"
+      }
+    },
     "cmp-lsp-nvim": {
       "flake": false,
       "locked": {
@@ -115,6 +147,22 @@
     "cmp-lsp-nvim_2": {
       "flake": false,
       "locked": {
+        "lastModified": 1755085771,
+        "narHash": "sha256-X1rppwf2xBPrmB93ptXukOnEBDZmfjJd4F5ObNa1DHs=",
+        "owner": "hrsh7th",
+        "repo": "cmp-nvim-lsp",
+        "rev": "bd5a7d6db125d4654b50eeae9f5217f24bb22fd3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-nvim-lsp",
+        "type": "github"
+      }
+    },
+    "cmp-lsp-nvim_3": {
+      "flake": false,
+      "locked": {
         "lastModified": 1743496195,
         "narHash": "sha256-iaihXNCF5bB5MdeoosD/kc3QtpA/QaIDZVLiLIurBSM=",
         "owner": "hrsh7th",
@@ -128,7 +176,7 @@
         "type": "github"
       }
     },
-    "cmp-lsp-nvim_3": {
+    "cmp-lsp-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1743496195,
@@ -192,6 +240,22 @@
         "type": "github"
       }
     },
+    "cmp-luasnip-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1730707109,
+        "narHash": "sha256-86lKQPPyqFz8jzuLajjHMKHrYnwW6+QOcPyQEx6B+gw=",
+        "owner": "saadparwaiz1",
+        "repo": "cmp_luasnip",
+        "rev": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "saadparwaiz1",
+        "repo": "cmp_luasnip",
+        "type": "github"
+      }
+    },
     "cmp-path-nvim": {
       "flake": false,
       "locked": {
@@ -240,7 +304,39 @@
         "type": "github"
       }
     },
+    "cmp-path-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753844861,
+        "narHash": "sha256-e4Rd2y1Wekp7aobpTGaUeoSBnlfIASDaBR8js5dh2Vw=",
+        "owner": "hrsh7th",
+        "repo": "cmp-path",
+        "rev": "c642487086dbd9a93160e1679a1327be111cbc25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-path",
+        "type": "github"
+      }
+    },
     "codecompanion-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755364741,
+        "narHash": "sha256-RDyps9haPW/QRk13Mw0erv1vRjFm9g3PgjJOV1xZtnE=",
+        "owner": "olimorris",
+        "repo": "codecompanion.nvim",
+        "rev": "bc5ec92b5f4b8542150a6ae2e77422ec50f440a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olimorris",
+        "repo": "codecompanion.nvim",
+        "type": "github"
+      }
+    },
+    "codecompanion-nvim_2": {
       "flake": false,
       "locked": {
         "lastModified": 1755193374,
@@ -256,7 +352,7 @@
         "type": "github"
       }
     },
-    "codecompanion-nvim_2": {
+    "codecompanion-nvim_3": {
       "flake": false,
       "locked": {
         "lastModified": 1754561654,
@@ -272,7 +368,7 @@
         "type": "github"
       }
     },
-    "codecompanion-nvim_3": {
+    "codecompanion-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1754561654,
@@ -321,6 +417,22 @@
       }
     },
     "comment-nvim_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717957420,
+        "narHash": "sha256-h0kPue5Eqd5aeu4VoLH45pF0DmWWo1d8SnLICSQ63zc=",
+        "owner": "numToStr",
+        "repo": "Comment.nvim",
+        "rev": "e30b7f2008e52442154b66f7c519bfd2f1e32acb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numToStr",
+        "repo": "Comment.nvim",
+        "type": "github"
+      }
+    },
+    "comment-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1717957420,
@@ -432,9 +544,43 @@
         "type": "github"
       }
     },
+    "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -464,6 +610,8 @@
           "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "hercules-ci-effects",
           "nixpkgs"
@@ -485,6 +633,8 @@
     "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "neovim-nightly-overlay",
@@ -510,6 +660,8 @@
         "nixpkgs-lib": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "hercules-ci-effects",
           "nixpkgs"
@@ -531,6 +683,8 @@
     "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -552,6 +706,8 @@
     "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "hercules-ci-effects",
           "nixpkgs"
@@ -563,6 +719,48 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_8": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim-nightly-overlay",
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -591,6 +789,78 @@
     "flake-utils_10": {
       "inputs": {
         "systems": "systems_10"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_11": {
+      "inputs": {
+        "systems": "systems_11"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_12": {
+      "inputs": {
+        "systems": "systems_12"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_13": {
+      "inputs": {
+        "systems": "systems_13"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_14": {
+      "inputs": {
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -701,11 +971,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -757,7 +1027,32 @@
         "hypr-contrib": "hypr-contrib",
         "iff-dwm": "iff-dwm",
         "nihilistic-nvim": "nihilistic-nvim",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_11",
+        "osh-oxy": "osh-oxy_3",
+        "zsh-syntax-highlighting": "zsh-syntax-highlighting_3"
+      },
+      "locked": {
+        "lastModified": 1755431028,
+        "narHash": "sha256-W2O0uLM5ZmErC2Ld975QUW7Zfk2zyYTdC/jEtuTJ63c=",
+        "owner": "iff",
+        "repo": "fleet",
+        "rev": "69f913ae6d7e05e30fabd817eb89505728b7835f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iff",
+        "repo": "fleet",
+        "type": "github"
+      }
+    },
+    "fleet_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "home-manager": "home-manager_2",
+        "hypr-contrib": "hypr-contrib_2",
+        "iff-dwm": "iff-dwm_2",
+        "nihilistic-nvim": "nihilistic-nvim_2",
+        "nixpkgs": "nixpkgs_8",
         "osh-oxy": "osh-oxy_2",
         "zsh-syntax-highlighting": "zsh-syntax-highlighting_2"
       },
@@ -775,14 +1070,14 @@
         "type": "github"
       }
     },
-    "fleet_2": {
+    "fleet_3": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "home-manager": "home-manager_2",
-        "hypr-contrib": "hypr-contrib_2",
-        "iff-dwm": "iff-dwm_2",
-        "nihilistic-nvim": "nihilistic-nvim_2",
-        "nixpkgs": "nixpkgs_4",
+        "flake-utils": "flake-utils_6",
+        "home-manager": "home-manager_3",
+        "hypr-contrib": "hypr-contrib_3",
+        "iff-dwm": "iff-dwm_3",
+        "nihilistic-nvim": "nihilistic-nvim_3",
+        "nixpkgs": "nixpkgs_5",
         "osh-oxy": "osh-oxy",
         "zsh-syntax-highlighting": "zsh-syntax-highlighting"
       },
@@ -848,6 +1143,22 @@
         "type": "github"
       }
     },
+    "fugitive-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752614839,
+        "narHash": "sha256-u39oObHCXk8uew5HyVdV1Z69Viilv3B7x1SUJxYXYLo=",
+        "owner": "tpope",
+        "repo": "vim-fugitive",
+        "rev": "61b51c09b7c9ce04e821f6cf76ea4f6f903e3cf4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tpope",
+        "repo": "vim-fugitive",
+        "type": "github"
+      }
+    },
     "funky-contexts-nvim": {
       "flake": false,
       "locked": {
@@ -881,6 +1192,22 @@
       }
     },
     "funky-contexts-nvim_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681225667,
+        "narHash": "sha256-GsRgrc0v9pQ/rjMEJ5N7C5VX6HRaduC59tJUsg8eQ0E=",
+        "owner": "dkuettel",
+        "repo": "funky-contexts.nvim",
+        "rev": "331af92dae135ba67523605d8534b3caf33cbe86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dkuettel",
+        "repo": "funky-contexts.nvim",
+        "type": "github"
+      }
+    },
+    "funky-contexts-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1681225667,
@@ -944,11 +1271,29 @@
         "type": "github"
       }
     },
+    "funky-formatter-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753902510,
+        "narHash": "sha256-AVwSRC/NQsBp7iBDPQuaG8MNEVo9fBUzKqeNpi/vif0=",
+        "owner": "dkuettel",
+        "repo": "funky-formatter.nvim",
+        "rev": "d69fb4eb62cfe85e4842c7104b61449d1a9a5683",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dkuettel",
+        "repo": "funky-formatter.nvim",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
         "gitignore": "gitignore",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -978,6 +1323,8 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -1001,6 +1348,31 @@
         "flake-compat": "flake-compat_6",
         "gitignore": "gitignore_3",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_4": {
+      "inputs": {
+        "flake-compat": "flake-compat_8",
+        "gitignore": "gitignore_4",
+        "nixpkgs": [
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -1022,6 +1394,8 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -1050,6 +1424,8 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "git-hooks",
           "nixpkgs"
@@ -1070,6 +1446,30 @@
       }
     },
     "gitignore_3": {
+      "inputs": {
+        "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
+          "neovim-nightly-overlay",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_4": {
       "inputs": {
         "nixpkgs": [
           "neovim-nightly-overlay",
@@ -1099,6 +1499,8 @@
           "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -1123,6 +1525,8 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -1145,6 +1549,8 @@
       "inputs": {
         "flake-parts": "flake-parts_6",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -1155,6 +1561,28 @@
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
         "rev": "5f2e09654b2e70ba643e41609d9f9b6640f22113",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects_4": {
+      "inputs": {
+        "flake-parts": "flake-parts_8",
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755233722,
+        "narHash": "sha256-AavrbMltJKcC2Fx0lfJoZfmy7g87ebXU0ddVenhajLA=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "99e03e72e3f7e13506f80ef9ebaedccb929d84d0",
         "type": "github"
       },
       "original": {
@@ -1187,6 +1615,31 @@
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
+          "fleet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755229570,
+        "narHash": "sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs+Z/VRTBg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "11626a4383b458f8dc5ea3237eaa04e8ab1912f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -1255,6 +1708,22 @@
         "type": "github"
       }
     },
+    "hop-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754504110,
+        "narHash": "sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA=",
+        "owner": "smoka7",
+        "repo": "hop.nvim",
+        "rev": "2254e0b3c8054b9ee661c9be3cb201d4b3384d8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "smoka7",
+        "repo": "hop.nvim",
+        "type": "github"
+      }
+    },
     "hypr-contrib": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -1291,6 +1760,24 @@
         "type": "github"
       }
     },
+    "hypr-contrib_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1753252360,
+        "narHash": "sha256-PFAJoEqQWMlo1J+yZb+4HixmhbRVmmNl58e/AkLYDDI=",
+        "owner": "hyprwm",
+        "repo": "contrib",
+        "rev": "6839b23345b71db17cd408373de4f5605bf589b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "contrib",
+        "type": "github"
+      }
+    },
     "iff-dwm": {
       "flake": false,
       "locked": {
@@ -1309,6 +1796,23 @@
       }
     },
     "iff-dwm_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732213561,
+        "narHash": "sha256-tHYqRGM/U5Bkp8tReWylUw+LdtgYA4UVFt++oLCw19E=",
+        "owner": "iff",
+        "repo": "dwm",
+        "rev": "3039b429b4580ca7bca7be5cd19f3ae266a33e01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iff",
+        "ref": "nixos",
+        "repo": "dwm",
+        "type": "github"
+      }
+    },
+    "iff-dwm_3": {
       "flake": false,
       "locked": {
         "lastModified": 1732213561,
@@ -1373,6 +1877,22 @@
         "type": "github"
       }
     },
+    "kmonad-vim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647812451,
+        "narHash": "sha256-7PKVOsb3jvuGEnP/LsrDr96wFSQMou2dgnV+hRaI444=",
+        "owner": "kmonad",
+        "repo": "kmonad-vim",
+        "rev": "37978445197ab00edeb5b731e9ca90c2b141723f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kmonad",
+        "repo": "kmonad-vim",
+        "type": "github"
+      }
+    },
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
@@ -1406,6 +1926,22 @@
       }
     },
     "lavish-layouts-nvim_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754256310,
+        "narHash": "sha256-02sk11tKvsT+R+UMGFmYGehD+sQuBUFiij0T+F/VtOU=",
+        "owner": "dkuettel",
+        "repo": "lavish-layouts.nvim",
+        "rev": "6862bce269f99518d93264d8100a91b1e2d93c67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dkuettel",
+        "repo": "lavish-layouts.nvim",
+        "type": "github"
+      }
+    },
+    "lavish-layouts-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1754256310,
@@ -1485,6 +2021,22 @@
         "type": "github"
       }
     },
+    "lspkind-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733408701,
+        "narHash": "sha256-OCvKUBGuzwy8OWOL1x3Z3fo+0+GyBMI9TX41xSveqvE=",
+        "owner": "onsails",
+        "repo": "lspkind.nvim",
+        "rev": "d79a1c3299ad0ef94e255d045bed9fa26025dab6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "onsails",
+        "repo": "lspkind.nvim",
+        "type": "github"
+      }
+    },
     "lualine-nvim": {
       "flake": false,
       "locked": {
@@ -1518,6 +2070,22 @@
       }
     },
     "lualine-nvim_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754970649,
+        "narHash": "sha256-lWt2kpW+hsTMWt8tar/+AISTDrIt4Jn27NmI9j+Xt4s=",
+        "owner": "nvim-lualine",
+        "repo": "lualine.nvim",
+        "rev": "b8c23159c0161f4b89196f74ee3a6d02cdc3a955",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-lualine",
+        "repo": "lualine.nvim",
+        "type": "github"
+      }
+    },
+    "lualine-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1754970649,
@@ -1581,6 +2149,22 @@
         "type": "github"
       }
     },
+    "luasnip-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754037237,
+        "narHash": "sha256-JhTqTGQfIryJ7MElcOGOfb48uaNDnd9RM9Fl1Fs4QV0=",
+        "owner": "L3MON4D3",
+        "repo": "LuaSnip",
+        "rev": "de10d8414235b0a8cabfeba60d07c24304e71f5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "L3MON4D3",
+        "repo": "LuaSnip",
+        "type": "github"
+      }
+    },
     "neodev-nvim": {
       "flake": false,
       "locked": {
@@ -1629,6 +2213,22 @@
         "type": "github"
       }
     },
+    "neodev-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720260306,
+        "narHash": "sha256-hOjzlo/IqmV8tYjGwfmcCPEmHYsWnEIwtHZdhpwA1kM=",
+        "owner": "folke",
+        "repo": "neodev.nvim",
+        "rev": "46aa467dca16cf3dfe27098042402066d2ae242d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "folke",
+        "repo": "neodev.nvim",
+        "type": "github"
+      }
+    },
     "neovim-nightly-overlay": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -1637,6 +2237,8 @@
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-src": "neovim-src",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -1669,6 +2271,8 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "nixpkgs"
         ],
         "treefmt-nix": "treefmt-nix_2"
@@ -1695,6 +2299,8 @@
         "hercules-ci-effects": "hercules-ci-effects_3",
         "neovim-src": "neovim-src_3",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "nixpkgs"
         ],
         "treefmt-nix": "treefmt-nix_3"
@@ -1705,6 +2311,32 @@
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
         "rev": "73fca33ad4ddc8fe41192e23dae9af0544798653",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "neovim-nightly-overlay_4": {
+      "inputs": {
+        "flake-compat": "flake-compat_7",
+        "flake-parts": "flake-parts_7",
+        "git-hooks": "git-hooks_4",
+        "hercules-ci-effects": "hercules-ci-effects_4",
+        "neovim-src": "neovim-src_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_4"
+      },
+      "locked": {
+        "lastModified": 1755439635,
+        "narHash": "sha256-c7GDrCNRC+2Kgty6pTAdgxDp2mDUoBCI77J3JhH0nss=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "8a97ada3e7c4d8105f4525ba0fe7fdda19bf497f",
         "type": "github"
       },
       "original": {
@@ -1761,6 +2393,22 @@
         "type": "github"
       }
     },
+    "neovim-src_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755380888,
+        "narHash": "sha256-BTPhH335sUyQE8XvrmvtiOpsdDsDMzcKaCiV+sjeGAY=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "5f8d4a248a97b7beb26a097811dce92f1b18e260",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
     "nightfox-nvim": {
       "flake": false,
       "locked": {
@@ -1809,6 +2457,22 @@
         "type": "github"
       }
     },
+    "nightfox-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739121671,
+        "narHash": "sha256-HoZEwncrUnypWxyB+XR0UQDv+tNu1/NbvimxYGb7qu8=",
+        "owner": "EdenEast",
+        "repo": "nightfox.nvim",
+        "rev": "ba47d4b4c5ec308718641ba7402c143836f35aa9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EdenEast",
+        "repo": "nightfox.nvim",
+        "type": "github"
+      }
+    },
     "nihilistic-nvim": {
       "inputs": {
         "auspicious-autosave-nvim": "auspicious-autosave-nvim_2",
@@ -1820,6 +2484,56 @@
         "comment-nvim": "comment-nvim_2",
         "flake-utils": "flake-utils_3",
         "fleet": "fleet_2",
+        "fugitive-nvim": "fugitive-nvim_3",
+        "funky-contexts-nvim": "funky-contexts-nvim_3",
+        "funky-formatter-nvim": "funky-formatter-nvim_3",
+        "hop-nvim": "hop-nvim_3",
+        "kmonad-vim": "kmonad-vim_3",
+        "lavish-layouts-nvim": "lavish-layouts-nvim_3",
+        "lspkind-nvim": "lspkind-nvim_3",
+        "lualine-nvim": "lualine-nvim_3",
+        "luasnip-nvim": "luasnip-nvim_3",
+        "neodev-nvim": "neodev-nvim_3",
+        "neovim-nightly-overlay": "neovim-nightly-overlay_3",
+        "nightfox-nvim": "nightfox-nvim_3",
+        "nixpkgs": [
+          "fleet",
+          "nixpkgs"
+        ],
+        "nvim-lspconfig": "nvim-lspconfig_3",
+        "ptags-nvim": "ptags-nvim_3",
+        "resty-vim": "resty-vim_3",
+        "telescope-fzf-native-nvim": "telescope-fzf-native-nvim_3",
+        "telescope-hop-nvim": "telescope-hop-nvim_3",
+        "telescope-nvim": "telescope-nvim_3",
+        "telescope-ui-select-nvim": "telescope-ui-select-nvim_3",
+        "web-devicons-nvim": "web-devicons-nvim_3"
+      },
+      "locked": {
+        "lastModified": 1755430827,
+        "narHash": "sha256-3/xu/Cnkmf0lTfKZbMZiwOk3bM3RX8OzWFWhu5KZv7Y=",
+        "owner": "iff",
+        "repo": "nihilistic-nvim",
+        "rev": "c77dd8193e7defbfd1a053fe74a0996e7a0bf87c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iff",
+        "repo": "nihilistic-nvim",
+        "type": "github"
+      }
+    },
+    "nihilistic-nvim_2": {
+      "inputs": {
+        "auspicious-autosave-nvim": "auspicious-autosave-nvim_3",
+        "cmp-buffer-nvim": "cmp-buffer-nvim_3",
+        "cmp-lsp-nvim": "cmp-lsp-nvim_3",
+        "cmp-luasnip-nvim": "cmp-luasnip-nvim_3",
+        "cmp-path-nvim": "cmp-path-nvim_3",
+        "codecompanion-nvim": "codecompanion-nvim_3",
+        "comment-nvim": "comment-nvim_3",
+        "flake-utils": "flake-utils_5",
+        "fleet": "fleet_3",
         "fugitive-nvim": "fugitive-nvim_2",
         "funky-contexts-nvim": "funky-contexts-nvim_2",
         "funky-formatter-nvim": "funky-formatter-nvim_2",
@@ -1833,6 +2547,8 @@
         "neovim-nightly-overlay": "neovim-nightly-overlay_2",
         "nightfox-nvim": "nightfox-nvim_2",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nixpkgs"
         ],
@@ -1859,16 +2575,16 @@
         "type": "github"
       }
     },
-    "nihilistic-nvim_2": {
+    "nihilistic-nvim_3": {
       "inputs": {
-        "auspicious-autosave-nvim": "auspicious-autosave-nvim_3",
-        "cmp-buffer-nvim": "cmp-buffer-nvim_3",
-        "cmp-lsp-nvim": "cmp-lsp-nvim_3",
-        "cmp-luasnip-nvim": "cmp-luasnip-nvim_3",
-        "cmp-path-nvim": "cmp-path-nvim_3",
-        "codecompanion-nvim": "codecompanion-nvim_3",
-        "comment-nvim": "comment-nvim_3",
-        "flake-utils": "flake-utils_5",
+        "auspicious-autosave-nvim": "auspicious-autosave-nvim_4",
+        "cmp-buffer-nvim": "cmp-buffer-nvim_4",
+        "cmp-lsp-nvim": "cmp-lsp-nvim_4",
+        "cmp-luasnip-nvim": "cmp-luasnip-nvim_4",
+        "cmp-path-nvim": "cmp-path-nvim_4",
+        "codecompanion-nvim": "codecompanion-nvim_4",
+        "comment-nvim": "comment-nvim_4",
+        "flake-utils": "flake-utils_7",
         "fugitive-nvim": "fugitive-nvim",
         "funky-contexts-nvim": "funky-contexts-nvim",
         "funky-formatter-nvim": "funky-formatter-nvim",
@@ -1883,6 +2599,8 @@
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nightfox-nvim": "nightfox-nvim",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -1927,6 +2645,70 @@
         "type": "github"
       }
     },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1753345091,
+        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1755175540,
+        "narHash": "sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a595dde4d0d31606e19dcec73db02279db59d201",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1753345091,
+        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1712163089,
@@ -1945,6 +2727,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1753345091,
         "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
         "owner": "nixos",
@@ -1959,7 +2757,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1754640348,
         "narHash": "sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E=",
@@ -1975,7 +2773,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -1991,7 +2789,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1753345091,
         "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
@@ -2007,7 +2805,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1755175540,
         "narHash": "sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4=",
@@ -2023,7 +2821,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -2035,22 +2833,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1753345091,
-        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -2103,10 +2885,28 @@
         "type": "github"
       }
     },
+    "nvim-lspconfig_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755461203,
+        "narHash": "sha256-pVkQRrrz66Vk16Gfwl8H9X6pJCUXXUmtnN9E8qTLkcs=",
+        "owner": "neovim",
+        "repo": "nvim-lspconfig",
+        "rev": "782dda984da54e465dcc142544133606139d0306",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "nvim-lspconfig",
+        "type": "github"
+      }
+    },
     "osh-oxy": {
       "inputs": {
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -2130,8 +2930,10 @@
     },
     "osh-oxy_2": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_11",
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nixpkgs"
         ],
@@ -2151,10 +2953,33 @@
         "type": "github"
       }
     },
+    "osh-oxy_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_13",
+        "nixpkgs": [
+          "fleet",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_3"
+      },
+      "locked": {
+        "lastModified": 1750421969,
+        "narHash": "sha256-Lozd4zrME/cmX6M/+1EJZJwroldfkoQMqKsObpg0YN4=",
+        "owner": "iff",
+        "repo": "osh-oxy",
+        "rev": "cc54d33a57fad8bf57ed1984293490bd230adc5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iff",
+        "repo": "osh-oxy",
+        "type": "github"
+      }
+    },
     "ptags-nvim": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_3",
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": "nixpkgs_4",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
         "uv2nix": "uv2nix"
@@ -2175,8 +3000,8 @@
     },
     "ptags-nvim_2": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_6",
+        "flake-utils": "flake-utils_10",
+        "nixpkgs": "nixpkgs_7",
         "pyproject-build-systems": "pyproject-build-systems_2",
         "pyproject-nix": "pyproject-nix_2",
         "uv2nix": "uv2nix_2"
@@ -2197,11 +3022,33 @@
     },
     "ptags-nvim_3": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_9",
+        "flake-utils": "flake-utils_12",
+        "nixpkgs": "nixpkgs_10",
         "pyproject-build-systems": "pyproject-build-systems_3",
         "pyproject-nix": "pyproject-nix_3",
         "uv2nix": "uv2nix_3"
+      },
+      "locked": {
+        "lastModified": 1753629005,
+        "narHash": "sha256-jZdoL5EcwzdeFb6elTTy9rbABUevXuaP2uV+NJQHwdc=",
+        "owner": "dkuettel",
+        "repo": "ptags.nvim",
+        "rev": "a7e5e7070f0505f29f8a7bb8e7bf1cc1a6a9223f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dkuettel",
+        "repo": "ptags.nvim",
+        "type": "github"
+      }
+    },
+    "ptags-nvim_4": {
+      "inputs": {
+        "flake-utils": "flake-utils_14",
+        "nixpkgs": "nixpkgs_13",
+        "pyproject-build-systems": "pyproject-build-systems_4",
+        "pyproject-nix": "pyproject-nix_4",
+        "uv2nix": "uv2nix_4"
       },
       "locked": {
         "lastModified": 1753629005,
@@ -2224,6 +3071,8 @@
           "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "ptags-nvim",
           "nixpkgs"
         ],
@@ -2232,10 +3081,14 @@
           "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "ptags-nvim",
           "pyproject-nix"
         ],
         "uv2nix": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -2263,6 +3116,47 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
+          "ptags-nvim",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "fleet",
+          "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
+          "ptags-nvim",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "fleet",
+          "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
+          "ptags-nvim",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753063383,
+        "narHash": "sha256-H+gLv6424OjJSD+l1OU1ejxkN/v0U+yaoQdh2huCXYI=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "45888b7fd4bf36c57acc55f07917bdf49ec89ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems_3": {
+      "inputs": {
+        "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "ptags-nvim",
           "nixpkgs"
         ],
@@ -2293,7 +3187,7 @@
         "type": "github"
       }
     },
-    "pyproject-build-systems_3": {
+    "pyproject-build-systems_4": {
       "inputs": {
         "nixpkgs": [
           "ptags-nvim",
@@ -2329,6 +3223,8 @@
           "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "ptags-nvim",
           "nixpkgs"
         ]
@@ -2352,6 +3248,8 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "ptags-nvim",
           "nixpkgs"
         ]
@@ -2371,6 +3269,29 @@
       }
     },
     "pyproject-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
+          "ptags-nvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753063596,
+        "narHash": "sha256-el1vFxDk6DR2hKGYnMfQHR7+K4aMiJDKQRMP3gdh+ZI=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "cac90713492f23be5f1072bae88406890b9c68f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_4": {
       "inputs": {
         "nixpkgs": [
           "ptags-nvim",
@@ -2439,6 +3360,22 @@
         "type": "github"
       }
     },
+    "resty-vim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755454338,
+        "narHash": "sha256-7CABjYC4QWFMWY3OybaqRMG5YN/gtBnntJzNeE2UJXs=",
+        "owner": "lima1909",
+        "repo": "resty.nvim",
+        "rev": "1d03fa71616fc1d9bf412eb10ce7d08412bd9fd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lima1909",
+        "repo": "resty.nvim",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "auspicious-autosave-nvim": "auspicious-autosave-nvim",
@@ -2450,35 +3387,35 @@
         "comment-nvim": "comment-nvim",
         "flake-utils": "flake-utils",
         "fleet": "fleet",
-        "fugitive-nvim": "fugitive-nvim_3",
-        "funky-contexts-nvim": "funky-contexts-nvim_3",
-        "funky-formatter-nvim": "funky-formatter-nvim_3",
-        "hop-nvim": "hop-nvim_3",
-        "kmonad-vim": "kmonad-vim_3",
-        "lavish-layouts-nvim": "lavish-layouts-nvim_3",
-        "lspkind-nvim": "lspkind-nvim_3",
-        "lualine-nvim": "lualine-nvim_3",
-        "luasnip-nvim": "luasnip-nvim_3",
-        "neodev-nvim": "neodev-nvim_3",
-        "neovim-nightly-overlay": "neovim-nightly-overlay_3",
-        "nightfox-nvim": "nightfox-nvim_3",
+        "fugitive-nvim": "fugitive-nvim_4",
+        "funky-contexts-nvim": "funky-contexts-nvim_4",
+        "funky-formatter-nvim": "funky-formatter-nvim_4",
+        "hop-nvim": "hop-nvim_4",
+        "kmonad-vim": "kmonad-vim_4",
+        "lavish-layouts-nvim": "lavish-layouts-nvim_4",
+        "lspkind-nvim": "lspkind-nvim_4",
+        "lualine-nvim": "lualine-nvim_4",
+        "luasnip-nvim": "luasnip-nvim_4",
+        "neodev-nvim": "neodev-nvim_4",
+        "neovim-nightly-overlay": "neovim-nightly-overlay_4",
+        "nightfox-nvim": "nightfox-nvim_4",
         "nixpkgs": [
           "fleet",
           "nixpkgs"
         ],
-        "nvim-lspconfig": "nvim-lspconfig_3",
-        "ptags-nvim": "ptags-nvim_3",
-        "resty-vim": "resty-vim_3",
-        "telescope-fzf-native-nvim": "telescope-fzf-native-nvim_3",
-        "telescope-hop-nvim": "telescope-hop-nvim_3",
-        "telescope-nvim": "telescope-nvim_3",
-        "telescope-ui-select-nvim": "telescope-ui-select-nvim_3",
-        "web-devicons-nvim": "web-devicons-nvim_3"
+        "nvim-lspconfig": "nvim-lspconfig_4",
+        "ptags-nvim": "ptags-nvim_4",
+        "resty-vim": "resty-vim_4",
+        "telescope-fzf-native-nvim": "telescope-fzf-native-nvim_4",
+        "telescope-hop-nvim": "telescope-hop-nvim_4",
+        "telescope-nvim": "telescope-nvim_4",
+        "telescope-ui-select-nvim": "telescope-ui-select-nvim_4",
+        "web-devicons-nvim": "web-devicons-nvim_4"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1750387093,
@@ -2496,7 +3433,25 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_9"
+      },
+      "locked": {
+        "lastModified": 1750387093,
+        "narHash": "sha256-MgL1+yNVcSD6OlzSmKt5GS4RmAQnNCjckjgPC1hmMPg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "517e9871d182346b53bb7f23fed00810c14db396",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1750387093,
@@ -2528,6 +3483,66 @@
       }
     },
     "systems_10": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_11": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_12": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_13": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_14": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2710,6 +3725,22 @@
         "type": "github"
       }
     },
+    "telescope-fzf-native-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741765009,
+        "narHash": "sha256-Zyv8ikxdwoUiDD0zsqLzfhBVOm/nKyJdZpndxXEB6ow=",
+        "owner": "nvim-telescope",
+        "repo": "telescope-fzf-native.nvim",
+        "rev": "1f08ed60cafc8f6168b72b80be2b2ea149813e55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-telescope",
+        "repo": "telescope-fzf-native.nvim",
+        "type": "github"
+      }
+    },
     "telescope-hop-nvim": {
       "flake": false,
       "locked": {
@@ -2743,6 +3774,22 @@
       }
     },
     "telescope-hop-nvim_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636109078,
+        "narHash": "sha256-OtCSjglHdXKj9EqnaTzw+4/L+op/lJ82CxlvxPLsee8=",
+        "owner": "nvim-telescope",
+        "repo": "telescope-hop.nvim",
+        "rev": "337a1e9f08f972ebf7a7d26251577812ebaadc78",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-telescope",
+        "repo": "telescope-hop.nvim",
+        "type": "github"
+      }
+    },
+    "telescope-hop-nvim_4": {
       "flake": false,
       "locked": {
         "lastModified": 1636109078,
@@ -2806,6 +3853,22 @@
         "type": "github"
       }
     },
+    "telescope-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747012888,
+        "narHash": "sha256-JpW0ehsX81yVbKNzrYOe1hdgVMs6oaaxMLH6lECnOJg=",
+        "owner": "nvim-telescope",
+        "repo": "telescope.nvim",
+        "rev": "b4da76be54691e854d3e0e02c36b0245f945c2c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-telescope",
+        "repo": "telescope.nvim",
+        "type": "github"
+      }
+    },
     "telescope-ui-select-nvim": {
       "flake": false,
       "locked": {
@@ -2854,9 +3917,27 @@
         "type": "github"
       }
     },
+    "telescope-ui-select-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701723223,
+        "narHash": "sha256-YRhNmmG4gx9Ht8JwjQfbTjJyTHEuZmtP6lqnhOsk8bE=",
+        "owner": "nvim-telescope",
+        "repo": "telescope-ui-select.nvim",
+        "rev": "6e51d7da30bd139a6950adf2a47fda6df9fa06d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-telescope",
+        "repo": "telescope-ui-select.nvim",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
           "fleet",
@@ -2884,6 +3965,8 @@
         "nixpkgs": [
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -2903,6 +3986,29 @@
       }
     },
     "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754847726,
+        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "neovim-nightly-overlay",
@@ -2930,6 +4036,43 @@
           "nihilistic-nvim",
           "fleet",
           "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
+          "ptags-nvim",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "fleet",
+          "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
+          "ptags-nvim",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753400079,
+        "narHash": "sha256-VC76rfCgtaKPopaLOyAEZ80bpOTQDr7wEZRUCMjoacE=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "350ae196e0e414c03db118d385eabaf50e2a0a53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "fleet",
+          "nihilistic-nvim",
+          "fleet",
+          "nihilistic-nvim",
           "ptags-nvim",
           "nixpkgs"
         ],
@@ -2956,7 +4099,7 @@
         "type": "github"
       }
     },
-    "uv2nix_2": {
+    "uv2nix_3": {
       "inputs": {
         "nixpkgs": [
           "fleet",
@@ -2985,7 +4128,7 @@
         "type": "github"
       }
     },
-    "uv2nix_3": {
+    "uv2nix_4": {
       "inputs": {
         "nixpkgs": [
           "ptags-nvim",
@@ -3058,6 +4201,22 @@
         "type": "github"
       }
     },
+    "web-devicons-nvim_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754884337,
+        "narHash": "sha256-Zftd4xFYdCtof6IusN+E079yY2oMTNhJ/yznvLiiur0=",
+        "owner": "nvim-tree",
+        "repo": "nvim-web-devicons",
+        "rev": "c2599a81ecabaae07c49ff9b45dcd032a8d90f1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-tree",
+        "repo": "nvim-web-devicons",
+        "type": "github"
+      }
+    },
     "zsh-syntax-highlighting": {
       "flake": false,
       "locked": {
@@ -3075,6 +4234,22 @@
       }
     },
     "zsh-syntax-highlighting_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732201766,
+        "narHash": "sha256-KRsQEDRsJdF7LGOMTZuqfbW6xdV5S38wlgdcCM98Y/Q=",
+        "owner": "zsh-users",
+        "repo": "zsh-syntax-highlighting",
+        "rev": "5eb677bb0fa9a3e60f0eff031dc13926e093df92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zsh-users",
+        "repo": "zsh-syntax-highlighting",
+        "type": "github"
+      }
+    },
+    "zsh-syntax-highlighting_3": {
       "flake": false,
       "locked": {
         "lastModified": 1732201766,


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/c5aa3c6231f861f2ab20c886e0776c5b2f43bbe8?narHash=sha256-oZ9kwaFKlgrx2ji%2BOj6cbfLpKqQz10m7aoSXaqyX1gc%3D' (2025-08-14)
  → 'github:olimorris/codecompanion.nvim/bc5ec92b5f4b8542150a6ae2e77422ec50f440a1?narHash=sha256-RDyps9haPW/QRk13Mw0erv1vRjFm9g3PgjJOV1xZtnE%3D' (2025-08-16)
• Updated input 'fleet':
    'github:iff/fleet/bffd5382c7c952ab6bdd77650bdb2b3e3db9154c?narHash=sha256-Z10UcTB5zMreRW5ULczPEt6EEuW5tMPdFFNiWzYN%2BuM%3D' (2025-08-16)
  → 'github:iff/fleet/69f913ae6d7e05e30fabd817eb89505728b7835f?narHash=sha256-W2O0uLM5ZmErC2Ld975QUW7Zfk2zyYTdC/jEtuTJ63c%3D' (2025-08-17)
• Updated input 'fleet/nihilistic-nvim':
    'github:iff/nihilistic-nvim/753d24153d99550487c7664e11fb2fec05fe5a6a?narHash=sha256-g2njapapdu5HC2o9Pa7veMo6itJFccwrEUYKX%2Ba%2BipY%3D' (2025-08-14)
  → 'github:iff/nihilistic-nvim/c77dd8193e7defbfd1a053fe74a0996e7a0bf87c?narHash=sha256-3/xu/Cnkmf0lTfKZbMZiwOk3bM3RX8OzWFWhu5KZv7Y%3D' (2025-08-17)
• Updated input 'fleet/nihilistic-nvim/cmp-lsp-nvim':
    'github:hrsh7th/cmp-nvim-lsp/a8912b88ce488f411177fc8aed358b04dc246d7b?narHash=sha256-iaihXNCF5bB5MdeoosD/kc3QtpA/QaIDZVLiLIurBSM%3D' (2025-04-01)
  → 'github:hrsh7th/cmp-nvim-lsp/bd5a7d6db125d4654b50eeae9f5217f24bb22fd3?narHash=sha256-X1rppwf2xBPrmB93ptXukOnEBDZmfjJd4F5ObNa1DHs%3D' (2025-08-13)
• Updated input 'fleet/nihilistic-nvim/codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/19d665a9b13c0b05652c359c4302465b8b2543be?narHash=sha256-zY9uWB11mr/XDAw/l4HLAy3ZHaIhUiYlzUFbiKVFSvg%3D' (2025-08-07)
  → 'github:olimorris/codecompanion.nvim/c5aa3c6231f861f2ab20c886e0776c5b2f43bbe8?narHash=sha256-oZ9kwaFKlgrx2ji%2BOj6cbfLpKqQz10m7aoSXaqyX1gc%3D' (2025-08-14)
• Updated input 'fleet/nihilistic-nvim/fleet':
    'github:iff/fleet/e633c5a04e1ee7f2fb8102e935081b1b13c7de7d?narHash=sha256-PxjchwUU0UH9Xk/w70w7BMU7Anin0XFyT/0E3hzMEPo%3D' (2025-08-10)
  → 'github:iff/fleet/bffd5382c7c952ab6bdd77650bdb2b3e3db9154c?narHash=sha256-Z10UcTB5zMreRW5ULczPEt6EEuW5tMPdFFNiWzYN%2BuM%3D' (2025-08-16)
• Updated input 'fleet/nihilistic-nvim/fleet/home-manager':
    'github:nix-community/home-manager/cc2fa2331aebf9661d22bb507d362b39852ac73f?narHash=sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1%2Bcc%3D' (2025-08-08)
  → 'github:nix-community/home-manager/11626a4383b458f8dc5ea3237eaa04e8ab1912f3?narHash=sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs%2BZ/VRTBg%3D' (2025-08-15)
• Updated input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim':
    'github:iff/nihilistic-nvim/041392fb1371d28e6411eddb453cb5d62512afda?narHash=sha256-6Rk94qxEcWzru2Jmpb5ZusFpU012DrPECGL1tLZ/m2U%3D' (2025-08-09)
  → 'github:iff/nihilistic-nvim/753d24153d99550487c7664e11fb2fec05fe5a6a?narHash=sha256-g2njapapdu5HC2o9Pa7veMo6itJFccwrEUYKX%2Ba%2BipY%3D' (2025-08-14)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet':
    'github:iff/fleet/e633c5a04e1ee7f2fb8102e935081b1b13c7de7d?narHash=sha256-PxjchwUU0UH9Xk/w70w7BMU7Anin0XFyT/0E3hzMEPo%3D' (2025-08-10)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/home-manager':
    'github:nix-community/home-manager/cc2fa2331aebf9661d22bb507d362b39852ac73f?narHash=sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1%2Bcc%3D' (2025-08-08)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/home-manager/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/hypr-contrib':
    'github:hyprwm/contrib/6839b23345b71db17cd408373de4f5605bf589b8?narHash=sha256-PFAJoEqQWMlo1J%2ByZb%2B4HixmhbRVmmNl58e/AkLYDDI%3D' (2025-07-23)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/hypr-contrib/nixpkgs':
    'github:NixOS/nixpkgs/fd281bd6b7d3e32ddfa399853946f782553163b5?narHash=sha256-Um%2B8kTIrC19vD4/lUCN9/cU9kcOsD1O1m%2BaxJqQPyMM%3D' (2024-04-03)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/iff-dwm':
    'github:iff/dwm/3039b429b4580ca7bca7be5cd19f3ae266a33e01?narHash=sha256-tHYqRGM/U5Bkp8tReWylUw%2BLdtgYA4UVFt%2B%2BoLCw19E%3D' (2024-11-21)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim':
    'github:iff/nihilistic-nvim/041392fb1371d28e6411eddb453cb5d62512afda?narHash=sha256-6Rk94qxEcWzru2Jmpb5ZusFpU012DrPECGL1tLZ/m2U%3D' (2025-08-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/auspicious-autosave-nvim':
    'github:dkuettel/auspicious-autosave.nvim/a19edaf5619a1499c170b3479f9970761fa64f41?narHash=sha256-130aVlInsFwnw8LD5vXVRUp6b3VCzWOzVt640T/%2BDrs%3D' (2025-06-29)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-buffer-nvim':
    'github:hrsh7th/cmp-buffer/b74fab3656eea9de20a9b8116afa3cfc4ec09657?narHash=sha256-dG4U7MtnXThoa/PD%2BqFtCt76MQ14V1wX8GMYcvxEnbM%3D' (2025-04-01)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-lsp-nvim':
    'github:hrsh7th/cmp-nvim-lsp/a8912b88ce488f411177fc8aed358b04dc246d7b?narHash=sha256-iaihXNCF5bB5MdeoosD/kc3QtpA/QaIDZVLiLIurBSM%3D' (2025-04-01)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-luasnip-nvim':
    'github:saadparwaiz1/cmp_luasnip/98d9cb5c2c38532bd9bdb481067b20fea8f32e90?narHash=sha256-86lKQPPyqFz8jzuLajjHMKHrYnwW6%2BQOcPyQEx6B%2Bgw%3D' (2024-11-04)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-path-nvim':
    'github:hrsh7th/cmp-path/c642487086dbd9a93160e1679a1327be111cbc25?narHash=sha256-e4Rd2y1Wekp7aobpTGaUeoSBnlfIASDaBR8js5dh2Vw%3D' (2025-07-30)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/19d665a9b13c0b05652c359c4302465b8b2543be?narHash=sha256-zY9uWB11mr/XDAw/l4HLAy3ZHaIhUiYlzUFbiKVFSvg%3D' (2025-08-07)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/comment-nvim':
    'github:numToStr/Comment.nvim/e30b7f2008e52442154b66f7c519bfd2f1e32acb?narHash=sha256-h0kPue5Eqd5aeu4VoLH45pF0DmWWo1d8SnLICSQ63zc%3D' (2024-06-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/fugitive-nvim':
    'github:tpope/vim-fugitive/61b51c09b7c9ce04e821f6cf76ea4f6f903e3cf4?narHash=sha256-u39oObHCXk8uew5HyVdV1Z69Viilv3B7x1SUJxYXYLo%3D' (2025-07-15)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/funky-contexts-nvim':
    'github:dkuettel/funky-contexts.nvim/331af92dae135ba67523605d8534b3caf33cbe86?narHash=sha256-GsRgrc0v9pQ/rjMEJ5N7C5VX6HRaduC59tJUsg8eQ0E%3D' (2023-04-11)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/d69fb4eb62cfe85e4842c7104b61449d1a9a5683?narHash=sha256-AVwSRC/NQsBp7iBDPQuaG8MNEVo9fBUzKqeNpi/vif0%3D' (2025-07-30)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/hop-nvim':
    'github:smoka7/hop.nvim/2254e0b3c8054b9ee661c9be3cb201d4b3384d8e?narHash=sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA%3D' (2025-08-06)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/kmonad-vim':
    'github:kmonad/kmonad-vim/37978445197ab00edeb5b731e9ca90c2b141723f?narHash=sha256-7PKVOsb3jvuGEnP/LsrDr96wFSQMou2dgnV%2BhRaI444%3D' (2022-03-20)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lavish-layouts-nvim':
    'github:dkuettel/lavish-layouts.nvim/6862bce269f99518d93264d8100a91b1e2d93c67?narHash=sha256-02sk11tKvsT%2BR%2BUMGFmYGehD%2BsQuBUFiij0T%2BF/VtOU%3D' (2025-08-03)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lsp-indicator-nvim':
    'github:dkuettel/lsp-indicator.nvim/4dd032f7f81bfdfe3145de0bfe84cf90df4c8ea4?narHash=sha256-ntR7/fG9rhWC20cZi4hn0V5TY1gzQFO2w2Qm7yX%2BSew%3D' (2023-07-15)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lspkind-nvim':
    'github:onsails/lspkind.nvim/d79a1c3299ad0ef94e255d045bed9fa26025dab6?narHash=sha256-OCvKUBGuzwy8OWOL1x3Z3fo%2B0%2BGyBMI9TX41xSveqvE%3D' (2024-12-05)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lualine-nvim':
    'github:nvim-lualine/lualine.nvim/a94fc68960665e54408fe37dcf573193c4ce82c9?narHash=sha256-2aPgA7riA/FubQpTkqsxLKl7OZ8L6FkucNHc2QEx2HQ%3D' (2025-06-08)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/luasnip-nvim':
    'github:L3MON4D3/LuaSnip/de10d8414235b0a8cabfeba60d07c24304e71f5c?narHash=sha256-JhTqTGQfIryJ7MElcOGOfb48uaNDnd9RM9Fl1Fs4QV0%3D' (2025-08-01)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neodev-nvim':
    'github:folke/neodev.nvim/46aa467dca16cf3dfe27098042402066d2ae242d?narHash=sha256-hOjzlo/IqmV8tYjGwfmcCPEmHYsWnEIwtHZdhpwA1kM%3D' (2024-07-06)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/83aaf3085f808dec9ea1b5d16b216875a8081b37?narHash=sha256-eMoujl/X1lbdjRbC/HHCpZmUb5tqTAYSL1hocy%2Bo7nc%3D' (2025-08-08)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/flake-parts/nixpkgs-lib':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/9c52372878df6911f9afc1e2a1391f55e4dfc864?narHash=sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef%2B6fRcofA%3D' (2025-08-05)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394?narHash=sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs%3D' (2024-02-28)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/gitignore/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/5f2e09654b2e70ba643e41609d9f9b6640f22113?narHash=sha256-CNBgr4OZSuklGtNOa9CnTNo9%2BXceqn/EDAC1Tc43fH8%3D' (2025-07-15)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/flake-parts/nixpkgs-lib':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/038eb01b41b66379f75164507571497929f8847c?narHash=sha256-ORfF40X4BGiFxnLNQbdsQbUTW4TkUHfPqyZWHaYL5NE%3D' (2025-08-07)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/1298185c05a56bff66383a20be0b41a307f52228?narHash=sha256-B%2B3g9%2B76KlGe34Yk9za8AF3RL%2BlnbHXkLiVHLjYVOAc%3D' (2025-08-06)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/treefmt-nix/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nightfox-nvim':
    'github:EdenEast/nightfox.nvim/ba47d4b4c5ec308718641ba7402c143836f35aa9?narHash=sha256-HoZEwncrUnypWxyB%2BXR0UQDv%2BtNu1/NbvimxYGb7qu8%3D' (2025-02-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nvim-lspconfig':
    'github:neovim/nvim-lspconfig/9141be4c1332afc83bdf1b0278dbb030f75ff8e3?narHash=sha256-FJGFwDeA0HxEEawnytdH663aFdf7lKKTwDZw9XX3Jxg%3D' (2025-08-06)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim':
    'github:dkuettel/ptags.nvim/a7e5e7070f0505f29f8a7bb8e7bf1cc1a6a9223f?narHash=sha256-jZdoL5EcwzdeFb6elTTy9rbABUevXuaP2uV%2BNJQHwdc%3D' (2025-07-27)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/nixpkgs':
    'github:nixos/nixpkgs/3ff0e34b1383648053bba8ed03f201d3466f90c9?narHash=sha256-CdX2Rtvp5I8HGu9swBmYuq%2BILwRxpXdJwlpg8jvN4tU%3D' (2025-07-24)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/45888b7fd4bf36c57acc55f07917bdf49ec89ec9?narHash=sha256-H%2BgLv6424OjJSD%2Bl1OU1ejxkN/v0U%2ByaoQdh2huCXYI%3D' (2025-07-21)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems/pyproject-nix':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-nix'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems/uv2nix':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/cac90713492f23be5f1072bae88406890b9c68f6?narHash=sha256-el1vFxDk6DR2hKGYnMfQHR7%2BK4aMiJDKQRMP3gdh%2BZI%3D' (2025-07-21)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-nix/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix':
    'github:pyproject-nix/uv2nix/350ae196e0e414c03db118d385eabaf50e2a0a53?narHash=sha256-VC76rfCgtaKPopaLOyAEZ80bpOTQDr7wEZRUCMjoacE%3D' (2025-07-24)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix/pyproject-nix':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-nix'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/resty-vim':
    'github:lima1909/resty.nvim/bda1b3c4734cfbab567cf3bfcbd065b62129ebf7?narHash=sha256-Ox9Tk7VtvSUIUgr02zdptvWk/pZMhdFVlp0N5dmgtPo%3D' (2025-05-25)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-fzf-native-nvim':
    'github:nvim-telescope/telescope-fzf-native.nvim/1f08ed60cafc8f6168b72b80be2b2ea149813e55?narHash=sha256-Zyv8ikxdwoUiDD0zsqLzfhBVOm/nKyJdZpndxXEB6ow%3D' (2025-03-12)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-hop-nvim':
    'github:nvim-telescope/telescope-hop.nvim/337a1e9f08f972ebf7a7d26251577812ebaadc78?narHash=sha256-OtCSjglHdXKj9EqnaTzw%2B4/L%2Bop/lJ82CxlvxPLsee8%3D' (2021-11-05)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-nvim':
    'github:nvim-telescope/telescope.nvim/b4da76be54691e854d3e0e02c36b0245f945c2c7?narHash=sha256-JpW0ehsX81yVbKNzrYOe1hdgVMs6oaaxMLH6lECnOJg%3D' (2025-05-12)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-ui-select-nvim':
    'github:nvim-telescope/telescope-ui-select.nvim/6e51d7da30bd139a6950adf2a47fda6df9fa06d2?narHash=sha256-YRhNmmG4gx9Ht8JwjQfbTjJyTHEuZmtP6lqnhOsk8bE%3D' (2023-12-04)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/3362099de3368aa620a8105b19ed04c2053e38c0?narHash=sha256-OzLLsrDaAHcNqasrHiL0hRNH9XZtCyoKrUFeSt/Iol8%3D' (2025-08-01)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nixpkgs':
    'github:nixos/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1?narHash=sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E%3D' (2025-08-08)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy':
    'github:iff/osh-oxy/cc54d33a57fad8bf57ed1984293490bd230adc5a?narHash=sha256-Lozd4zrME/cmX6M/%2B1EJZJwroldfkoQMqKsObpg0YN4%3D' (2025-06-20)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/flake-utils':
    'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384?narHash=sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt%2BxmY%3D' (2023-09-12)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/nixpkgs':
    follows 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nixpkgs'
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/rust-overlay':
    'github:oxalica/rust-overlay/517e9871d182346b53bb7f23fed00810c14db396?narHash=sha256-MgL1%2ByNVcSD6OlzSmKt5GS4RmAQnNCjckjgPC1hmMPg%3D' (2025-06-20)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/rust-overlay/nixpkgs':
    'github:NixOS/nixpkgs/18dd725c29603f582cf1900e0d25f9f1063dbf11?narHash=sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38%3D' (2025-04-13)
• Added input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/zsh-syntax-highlighting':
    'github:zsh-users/zsh-syntax-highlighting/5eb677bb0fa9a3e60f0eff031dc13926e093df92?narHash=sha256-KRsQEDRsJdF7LGOMTZuqfbW6xdV5S38wlgdcCM98Y/Q%3D' (2024-11-21)
• Removed input 'fleet/nihilistic-nvim/fleet/nihilistic-nvim/lsp-indicator-nvim'
• Updated input 'fleet/nihilistic-nvim/fleet/nixpkgs':
    'github:nixos/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1?narHash=sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E%3D' (2025-08-08)
  → 'github:nixos/nixpkgs/a595dde4d0d31606e19dcec73db02279db59d201?narHash=sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4%3D' (2025-08-14)
• Updated input 'fleet/nihilistic-nvim/lualine-nvim':
    'github:nvim-lualine/lualine.nvim/a94fc68960665e54408fe37dcf573193c4ce82c9?narHash=sha256-2aPgA7riA/FubQpTkqsxLKl7OZ8L6FkucNHc2QEx2HQ%3D' (2025-06-08)
  → 'github:nvim-lualine/lualine.nvim/b8c23159c0161f4b89196f74ee3a6d02cdc3a955?narHash=sha256-lWt2kpW%2BhsTMWt8tar/%2BAISTDrIt4Jn27NmI9j%2BXt4s%3D' (2025-08-12)
• Updated input 'fleet/nihilistic-nvim/neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/83aaf3085f808dec9ea1b5d16b216875a8081b37?narHash=sha256-eMoujl/X1lbdjRbC/HHCpZmUb5tqTAYSL1hocy%2Bo7nc%3D' (2025-08-08)
  → 'github:nix-community/neovim-nightly-overlay/73fca33ad4ddc8fe41192e23dae9af0544798653?narHash=sha256-jFchbJjsVUF8kKlLHRrucG23T2iu%2B920PwWFMfvtksE%3D' (2025-08-15)
• Updated input 'fleet/nihilistic-nvim/neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/038eb01b41b66379f75164507571497929f8847c?narHash=sha256-ORfF40X4BGiFxnLNQbdsQbUTW4TkUHfPqyZWHaYL5NE%3D' (2025-08-07)
  → 'github:neovim/neovim/7afcfb6c9ac53cb4192974934d6cdc360f4bebc7?narHash=sha256-phbfQOUazngOSVscRUPZclPk0Cn%2BG4XHodbtef9ZT8M%3D' (2025-08-14)
• Updated input 'fleet/nihilistic-nvim/neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/1298185c05a56bff66383a20be0b41a307f52228?narHash=sha256-B%2B3g9%2B76KlGe34Yk9za8AF3RL%2BlnbHXkLiVHLjYVOAc%3D' (2025-08-06)
  → 'github:numtide/treefmt-nix/7d81f6fb2e19bf84f1c65135d1060d829fae2408?narHash=sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl%2BV/PsmIiJREG4rE%3D' (2025-08-10)
• Updated input 'fleet/nihilistic-nvim/nvim-lspconfig':
    'github:neovim/nvim-lspconfig/9141be4c1332afc83bdf1b0278dbb030f75ff8e3?narHash=sha256-FJGFwDeA0HxEEawnytdH663aFdf7lKKTwDZw9XX3Jxg%3D' (2025-08-06)
  → 'github:neovim/nvim-lspconfig/b0caeef0d835fbe19df6ad71dbc4345eaaea649c?narHash=sha256-zj4OfM/NAs5uhhXlSFKvwgKU6dor8W2/CSyrXbMtCP4%3D' (2025-08-15)
• Updated input 'fleet/nihilistic-nvim/web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/3362099de3368aa620a8105b19ed04c2053e38c0?narHash=sha256-OzLLsrDaAHcNqasrHiL0hRNH9XZtCyoKrUFeSt/Iol8%3D' (2025-08-01)
  → 'github:nvim-tree/nvim-web-devicons/c2599a81ecabaae07c49ff9b45dcd032a8d90f1a?narHash=sha256-Zftd4xFYdCtof6IusN%2BE079yY2oMTNhJ/yznvLiiur0%3D' (2025-08-11)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/73fca33ad4ddc8fe41192e23dae9af0544798653?narHash=sha256-jFchbJjsVUF8kKlLHRrucG23T2iu%2B920PwWFMfvtksE%3D' (2025-08-15)
  → 'github:nix-community/neovim-nightly-overlay/8a97ada3e7c4d8105f4525ba0fe7fdda19bf497f?narHash=sha256-c7GDrCNRC%2B2Kgty6pTAdgxDp2mDUoBCI77J3JhH0nss%3D' (2025-08-17)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/5f2e09654b2e70ba643e41609d9f9b6640f22113?narHash=sha256-CNBgr4OZSuklGtNOa9CnTNo9%2BXceqn/EDAC1Tc43fH8%3D' (2025-07-15)
  → 'github:hercules-ci/hercules-ci-effects/99e03e72e3f7e13506f80ef9ebaedccb929d84d0?narHash=sha256-AavrbMltJKcC2Fx0lfJoZfmy7g87ebXU0ddVenhajLA%3D' (2025-08-15)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/7afcfb6c9ac53cb4192974934d6cdc360f4bebc7?narHash=sha256-phbfQOUazngOSVscRUPZclPk0Cn%2BG4XHodbtef9ZT8M%3D' (2025-08-14)
  → 'github:neovim/neovim/5f8d4a248a97b7beb26a097811dce92f1b18e260?narHash=sha256-BTPhH335sUyQE8XvrmvtiOpsdDsDMzcKaCiV%2BsjeGAY%3D' (2025-08-16)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/b0caeef0d835fbe19df6ad71dbc4345eaaea649c?narHash=sha256-zj4OfM/NAs5uhhXlSFKvwgKU6dor8W2/CSyrXbMtCP4%3D' (2025-08-15)
  → 'github:neovim/nvim-lspconfig/782dda984da54e465dcc142544133606139d0306?narHash=sha256-pVkQRrrz66Vk16Gfwl8H9X6pJCUXXUmtnN9E8qTLkcs%3D' (2025-08-17)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/bda1b3c4734cfbab567cf3bfcbd065b62129ebf7?narHash=sha256-Ox9Tk7VtvSUIUgr02zdptvWk/pZMhdFVlp0N5dmgtPo%3D' (2025-05-25)
  → 'github:lima1909/resty.nvim/1d03fa71616fc1d9bf412eb10ce7d08412bd9fd4?narHash=sha256-7CABjYC4QWFMWY3OybaqRMG5YN/gtBnntJzNeE2UJXs%3D' (2025-08-17)

```

</p></details>

 - Updated input [`fleet/nihilistic-nvim/neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`1298185c` ➡️ `7d81f6fb`](https://github.com/numtide/treefmt-nix/compare/1298185c05a56bff66383a20be0b41a307f52228...7d81f6fb2e19bf84f1c65135d1060d829fae2408) <sub>(2025-08-06 to 2025-08-10)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-fzf-native-nvim`](https://github.com/nvim-telescope/telescope-fzf-native.nvim): [github.com/nvim-telescope/telescope-fzf-native.nvim](https://github.com/nvim-telescope/telescope-fzf-native.nvim/tree/1f08ed60cafc8f6168b72b80be2b2ea149813e55/)
 - Updated input [`fleet/nihilistic-nvim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`9141be4c` ➡️ `b0caeef0`](https://github.com/neovim/nvim-lspconfig/compare/9141be4c1332afc83bdf1b0278dbb030f75ff8e3...b0caeef0d835fbe19df6ad71dbc4345eaaea649c) <sub>(2025-08-06 to 2025-08-15)</sub>
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/treefmt-nix/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/9c52372878df6911f9afc1e2a1391f55e4dfc864/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-hop-nvim`](https://github.com/nvim-telescope/telescope-hop.nvim): [github.com/nvim-telescope/telescope-hop.nvim](https://github.com/nvim-telescope/telescope-hop.nvim/tree/337a1e9f08f972ebf7a7d26251577812ebaadc78/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/zsh-syntax-highlighting`](https://github.com/zsh-users/zsh-syntax-highlighting): [github.com/zsh-users/zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting/tree/5eb677bb0fa9a3e60f0eff031dc13926e093df92/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet`](https://github.com/iff/fleet): [github.com/iff/fleet](https://github.com/iff/fleet/tree/e633c5a04e1ee7f2fb8102e935081b1b13c7de7d/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/rust-overlay/nixpkgs`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/18dd725c29603f582cf1900e0d25f9f1063dbf11/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems/pyproject-nix`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/hop-nvim`](https://github.com/smoka7/hop.nvim): [github.com/smoka7/hop.nvim](https://github.com/smoka7/hop.nvim/tree/2254e0b3c8054b9ee661c9be3cb201d4b3384d8e/)
 - Updated input [`fleet/nihilistic-nvim/neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`83aaf308` ➡️ `73fca33a`](https://github.com/nix-community/neovim-nightly-overlay/compare/83aaf3085f808dec9ea1b5d16b216875a8081b37...73fca33ad4ddc8fe41192e23dae9af0544798653) <sub>(2025-08-08 to 2025-08-15)</sub>
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/flake-parts/nixpkgs-lib`: ``
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/flake-parts/nixpkgs-lib`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/auspicious-autosave-nvim`](https://github.com/dkuettel/auspicious-autosave.nvim): [github.com/dkuettel/auspicious-autosave.nvim](https://github.com/dkuettel/auspicious-autosave.nvim/tree/a19edaf5619a1499c170b3479f9970761fa64f41/)
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`7afcfb6c` ➡️ `5f8d4a24`](https://github.com/neovim/neovim/compare/7afcfb6c9ac53cb4192974934d6cdc360f4bebc7...5f8d4a248a97b7beb26a097811dce92f1b18e260) <sub>(2025-08-14 to 2025-08-16)</sub>
 - Updated input [`fleet/nihilistic-nvim/fleet`](https://github.com/iff/fleet): [`e633c5a0` ➡️ `bffd5382`](https://github.com/iff/fleet/compare/e633c5a04e1ee7f2fb8102e935081b1b13c7de7d...bffd5382c7c952ab6bdd77650bdb2b3e3db9154c) <sub>(2025-08-10 to 2025-08-16)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/rust-overlay`](https://github.com/oxalica/rust-overlay): [github.com/oxalica/rust-overlay](https://github.com/oxalica/rust-overlay/tree/517e9871d182346b53bb7f23fed00810c14db396/)
 - Updated input [`codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [`c5aa3c62` ➡️ `bc5ec92b`](https://github.com/olimorris/codecompanion.nvim/compare/c5aa3c6231f861f2ab20c886e0776c5b2f43bbe8...bc5ec92b5f4b8542150a6ae2e77422ec50f440a1) <sub>(2025-08-14 to 2025-08-16)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/9100a0f413b0c601e0533d1d94ffd501ce2e7885/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/fugitive-nvim`](https://github.com/tpope/vim-fugitive): [github.com/tpope/vim-fugitive](https://github.com/tpope/vim-fugitive/tree/61b51c09b7c9ce04e821f6cf76ea4f6f903e3cf4/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/resty-vim`](https://github.com/lima1909/resty.nvim): [github.com/lima1909/resty.nvim](https://github.com/lima1909/resty.nvim/tree/bda1b3c4734cfbab567cf3bfcbd065b62129ebf7/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/kmonad-vim`](https://github.com/kmonad/kmonad-vim): [github.com/kmonad/kmonad-vim](https://github.com/kmonad/kmonad-vim/tree/37978445197ab00edeb5b731e9ca90c2b141723f/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1/)
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`bda1b3c4` ➡️ `1d03fa71`](https://github.com/lima1909/resty.nvim/compare/bda1b3c4734cfbab567cf3bfcbd065b62129ebf7...1d03fa71616fc1d9bf412eb10ce7d08412bd9fd4) <sub>(2025-05-25 to 2025-08-17)</sub>
 - Removed input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/lsp-indicator-nvim`.
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [github.com/iff/nihilistic-nvim](https://github.com/iff/nihilistic-nvim/tree/041392fb1371d28e6411eddb453cb5d62512afda/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim`](https://github.com/dkuettel/ptags.nvim): [github.com/dkuettel/ptags.nvim](https://github.com/dkuettel/ptags.nvim/tree/a7e5e7070f0505f29f8a7bb8e7bf1cc1a6a9223f/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/af66ad14b28a127c5c0f3bbb298218fc63528a18/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [github.com/nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim/tree/b4da76be54691e854d3e0e02c36b0245f945c2c7/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-luasnip-nvim`](https://github.com/saadparwaiz1/cmp_luasnip): [github.com/saadparwaiz1/cmp_luasnip](https://github.com/saadparwaiz1/cmp_luasnip/tree/98d9cb5c2c38532bd9bdb481067b20fea8f32e90/)
 - Updated input [`fleet/nihilistic-nvim/web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`3362099d` ➡️ `c2599a81`](https://github.com/nvim-tree/nvim-web-devicons/compare/3362099de3368aa620a8105b19ed04c2053e38c0...c2599a81ecabaae07c49ff9b45dcd032a8d90f1a) <sub>(2025-08-01 to 2025-08-11)</sub>
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/nixpkgs`: ``
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`5f2e0965` ➡️ `99e03e72`](https://github.com/hercules-ci/hercules-ci-effects/compare/5f2e09654b2e70ba643e41609d9f9b6640f22113...99e03e72e3f7e13506f80ef9ebaedccb929d84d0) <sub>(2025-07-15 to 2025-08-15)</sub>
 - Updated input [`fleet/nihilistic-nvim/cmp-lsp-nvim`](https://github.com/hrsh7th/cmp-nvim-lsp): [`a8912b88` ➡️ `bd5a7d6d`](https://github.com/hrsh7th/cmp-nvim-lsp/compare/a8912b88ce488f411177fc8aed358b04dc246d7b...bd5a7d6db125d4654b50eeae9f5217f24bb22fd3) <sub>(2025-04-01 to 2025-08-13)</sub>
 - Updated input [`fleet/nihilistic-nvim/codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [`19d665a9` ➡️ `c5aa3c62`](https://github.com/olimorris/codecompanion.nvim/compare/19d665a9b13c0b05652c359c4302465b8b2543be...c5aa3c6231f861f2ab20c886e0776c5b2f43bbe8) <sub>(2025-08-07 to 2025-08-14)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/flake-utils`](https://github.com/numtide/flake-utils): [github.com/numtide/flake-utils](https://github.com/numtide/flake-utils/tree/ff7b65b44d01cf9ba6a71320833626af21126384/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/telescope-ui-select-nvim`](https://github.com/nvim-telescope/telescope-ui-select.nvim): [github.com/nvim-telescope/telescope-ui-select.nvim](https://github.com/nvim-telescope/telescope-ui-select.nvim/tree/6e51d7da30bd139a6950adf2a47fda6df9fa06d2/)
 - Updated input [`fleet/nihilistic-nvim/lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`a94fc689` ➡️ `b8c23159`](https://github.com/nvim-lualine/lualine.nvim/compare/a94fc68960665e54408fe37dcf573193c4ce82c9...b8c23159c0161f4b89196f74ee3a6d02cdc3a955) <sub>(2025-06-08 to 2025-08-12)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/funky-contexts-nvim`](https://github.com/dkuettel/funky-contexts.nvim): [github.com/dkuettel/funky-contexts.nvim](https://github.com/dkuettel/funky-contexts.nvim/tree/331af92dae135ba67523605d8534b3caf33cbe86/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/flake-utils/systems`](https://github.com/nix-systems/default): [github.com/nix-systems/default](https://github.com/nix-systems/default/tree/da67096a3b9bf56a91d16901293e51ba5b49a27e/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/comment-nvim`](https://github.com/numToStr/Comment.nvim): [github.com/numToStr/Comment.nvim](https://github.com/numToStr/Comment.nvim/tree/e30b7f2008e52442154b66f7c519bfd2f1e32acb/)
 - Updated input [`fleet/nihilistic-nvim/fleet/nixpkgs`](https://github.com/nixos/nixpkgs): [`a3f3e3f2` ➡️ `a595dde4`](https://github.com/nixos/nixpkgs/compare/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1...a595dde4d0d31606e19dcec73db02279db59d201) <sub>(2025-08-08 to 2025-08-14)</sub>
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/home-manager/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/iff-dwm`](https://github.com/iff/dwm): [github.com/iff/dwm](https://github.com/iff/dwm/tree/3039b429b4580ca7bca7be5cd19f3ae266a33e01/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [github.com/pyproject-nix/pyproject.nix](https://github.com/pyproject-nix/pyproject.nix/tree/cac90713492f23be5f1072bae88406890b9c68f6/)
 - Updated input [`fleet/nihilistic-nvim/fleet/home-manager`](https://github.com/nix-community/home-manager): [`cc2fa233` ➡️ `11626a43`](https://github.com/nix-community/home-manager/compare/cc2fa2331aebf9661d22bb507d362b39852ac73f...11626a4383b458f8dc5ea3237eaa04e8ab1912f3) <sub>(2025-08-08 to 2025-08-15)</sub>
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [github.com/nvim-lualine/lualine.nvim](https://github.com/nvim-lualine/lualine.nvim/tree/a94fc68960665e54408fe37dcf573193c4ce82c9/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [github.com/nvim-tree/nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons/tree/3362099de3368aa620a8105b19ed04c2053e38c0/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-nix/nixpkgs`: ``
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`73fca33a` ➡️ `8a97ada3`](https://github.com/nix-community/neovim-nightly-overlay/compare/73fca33ad4ddc8fe41192e23dae9af0544798653...8a97ada3e7c4d8105f4525ba0fe7fdda19bf497f) <sub>(2025-08-15 to 2025-08-17)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/home-manager`](https://github.com/nix-community/home-manager): [github.com/nix-community/home-manager](https://github.com/nix-community/home-manager/tree/cc2fa2331aebf9661d22bb507d362b39852ac73f/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-lsp-nvim`](https://github.com/hrsh7th/cmp-nvim-lsp): [github.com/hrsh7th/cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp/tree/a8912b88ce488f411177fc8aed358b04dc246d7b/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [github.com/pyproject-nix/build-system-pkgs](https://github.com/pyproject-nix/build-system-pkgs/tree/45888b7fd4bf36c57acc55f07917bdf49ec89ec9/)
 - Updated input [`fleet`](https://github.com/iff/fleet): [`bffd5382` ➡️ `69f913ae`](https://github.com/iff/fleet/compare/bffd5382c7c952ab6bdd77650bdb2b3e3db9154c...69f913ae6d7e05e30fabd817eb89505728b7835f) <sub>(2025-08-16 to 2025-08-17)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`77826244` ➡️ `af66ad14`](https://github.com/hercules-ci/flake-parts/compare/77826244401ea9de6e3bac47c2db46005e1f30b5...af66ad14b28a127c5c0f3bbb298218fc63528a18) <sub>(2025-07-01 to 2025-08-06)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [github.com/neovim/nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/tree/9141be4c1332afc83bdf1b0278dbb030f75ff8e3/)
 - Updated input [`fleet/nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`753d2415` ➡️ `c77dd819`](https://github.com/iff/nihilistic-nvim/compare/753d24153d99550487c7664e11fb2fec05fe5a6a...c77dd8193e7defbfd1a053fe74a0996e7a0bf87c) <sub>(2025-08-14 to 2025-08-17)</sub>
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/gitignore/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/hypr-contrib/nixpkgs`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/fd281bd6b7d3e32ddfa399853946f782553163b5/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neodev-nvim`](https://github.com/folke/neodev.nvim): [github.com/folke/neodev.nvim](https://github.com/folke/neodev.nvim/tree/46aa467dca16cf3dfe27098042402066d2ae242d/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/9100a0f413b0c601e0533d1d94ffd501ce2e7885/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/flake-utils/systems`](https://github.com/nix-systems/default): [github.com/nix-systems/default](https://github.com/nix-systems/default/tree/da67096a3b9bf56a91d16901293e51ba5b49a27e/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nixpkgs`: ``
 - Updated input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim`](https://github.com/iff/nihilistic-nvim): [`041392fb` ➡️ `753d2415`](https://github.com/iff/nihilistic-nvim/compare/041392fb1371d28e6411eddb453cb5d62512afda...753d24153d99550487c7664e11fb2fec05fe5a6a) <sub>(2025-08-09 to 2025-08-14)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/flake-utils`](https://github.com/numtide/flake-utils): [github.com/numtide/flake-utils](https://github.com/numtide/flake-utils/tree/11707dc2f618dd54ca8739b309ec4fc024de578b/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [github.com/neovim/neovim](https://github.com/neovim/neovim/tree/038eb01b41b66379f75164507571497929f8847c/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/hypr-contrib`](https://github.com/hyprwm/contrib): [github.com/hyprwm/contrib](https://github.com/hyprwm/contrib/tree/6839b23345b71db17cd408373de4f5605bf589b8/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy`](https://github.com/iff/osh-oxy): [github.com/iff/osh-oxy](https://github.com/iff/osh-oxy/tree/cc54d33a57fad8bf57ed1984293490bd230adc5a/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lsp-indicator-nvim`](https://github.com/dkuettel/lsp-indicator.nvim): [github.com/dkuettel/lsp-indicator.nvim](https://github.com/dkuettel/lsp-indicator.nvim/tree/4dd032f7f81bfdfe3145de0bfe84cf90df4c8ea4/)
 - Updated input [`fleet/nihilistic-nvim/neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`038eb01b` ➡️ `7afcfb6c`](https://github.com/neovim/neovim/compare/038eb01b41b66379f75164507571497929f8847c...7afcfb6c9ac53cb4192974934d6cdc360f4bebc7) <sub>(2025-08-07 to 2025-08-14)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/flake-utils/systems`](https://github.com/nix-systems/default): [github.com/nix-systems/default](https://github.com/nix-systems/default/tree/da67096a3b9bf56a91d16901293e51ba5b49a27e/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/flake-utils`](https://github.com/numtide/flake-utils): [github.com/numtide/flake-utils](https://github.com/numtide/flake-utils/tree/11707dc2f618dd54ca8739b309ec4fc024de578b/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/1298185c05a56bff66383a20be0b41a307f52228/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-path-nvim`](https://github.com/hrsh7th/cmp-path): [github.com/hrsh7th/cmp-path](https://github.com/hrsh7th/cmp-path/tree/c642487086dbd9a93160e1679a1327be111cbc25/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lavish-layouts-nvim`](https://github.com/dkuettel/lavish-layouts.nvim): [github.com/dkuettel/lavish-layouts.nvim](https://github.com/dkuettel/lavish-layouts.nvim/tree/6862bce269f99518d93264d8100a91b1e2d93c67/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix/pyproject-nix`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [github.com/dkuettel/funky-formatter.nvim](https://github.com/dkuettel/funky-formatter.nvim/tree/d69fb4eb62cfe85e4842c7104b61449d1a9a5683/)
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`b0caeef0` ➡️ `782dda98`](https://github.com/neovim/nvim-lspconfig/compare/b0caeef0d835fbe19df6ad71dbc4345eaaea649c...782dda984da54e465dcc142544133606139d0306) <sub>(2025-08-15 to 2025-08-17)</sub>
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [github.com/hercules-ci/hercules-ci-effects](https://github.com/hercules-ci/hercules-ci-effects/tree/5f2e09654b2e70ba643e41609d9f9b6640f22113/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/flake-utils/systems`](https://github.com/nix-systems/default): [github.com/nix-systems/default](https://github.com/nix-systems/default/tree/da67096a3b9bf56a91d16901293e51ba5b49a27e/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/3ff0e34b1383648053bba8ed03f201d3466f90c9/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [github.com/L3MON4D3/LuaSnip](https://github.com/L3MON4D3/LuaSnip/tree/de10d8414235b0a8cabfeba60d07c24304e71f5c/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/cmp-buffer-nvim`](https://github.com/hrsh7th/cmp-buffer): [github.com/hrsh7th/cmp-buffer](https://github.com/hrsh7th/cmp-buffer/tree/b74fab3656eea9de20a9b8116afa3cfc4ec09657/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [github.com/EdenEast/nightfox.nvim](https://github.com/EdenEast/nightfox.nvim/tree/ba47d4b4c5ec308718641ba7402c143836f35aa9/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/pyproject-build-systems/uv2nix`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/77826244401ea9de6e3bac47c2db46005e1f30b5/)
 - Added input `fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/osh-oxy/nixpkgs`: ``
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/flake-utils`](https://github.com/numtide/flake-utils): [github.com/numtide/flake-utils](https://github.com/numtide/flake-utils/tree/11707dc2f618dd54ca8739b309ec4fc024de578b/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/ptags-nvim/uv2nix`](https://github.com/pyproject-nix/uv2nix): [github.com/pyproject-nix/uv2nix](https://github.com/pyproject-nix/uv2nix/tree/350ae196e0e414c03db118d385eabaf50e2a0a53/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [github.com/onsails/lspkind.nvim](https://github.com/onsails/lspkind.nvim/tree/d79a1c3299ad0ef94e255d045bed9fa26025dab6/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [github.com/olimorris/codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim/tree/19d665a9b13c0b05652c359c4302465b8b2543be/)
 - Added input [`fleet/nihilistic-nvim/fleet/nihilistic-nvim/fleet/nihilistic-nvim/neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [github.com/nix-community/neovim-nightly-overlay](https://github.com/nix-community/neovim-nightly-overlay/tree/83aaf3085f808dec9ea1b5d16b216875a8081b37/)