### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "auspicious-autosave-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1751198988,
-        "narHash": "sha256-130aVlInsFwnw8LD5vXVRUp6b3VCzWOzVt640T/+Drs=",
+        "lastModified": 1755990581,
+        "narHash": "sha256-ZN2jRDuotQEboGE+AtAGAL2iUGKeQ9GVqSELoIAP4GM=",
         "owner": "dkuettel",
         "repo": "auspicious-autosave.nvim",
-        "rev": "a19edaf5619a1499c170b3479f9970761fa64f41",
+        "rev": "a3d47ad721d6ac6bfe585174dc95709cc2c48c08",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     "codecompanion-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1755364741,
-        "narHash": "sha256-RDyps9haPW/QRk13Mw0erv1vRjFm9g3PgjJOV1xZtnE=",
+        "lastModified": 1755937933,
+        "narHash": "sha256-B1oSN5TjmkRmihH6pDwjuFExz3j/3QIfkHEpYblYvLI=",
         "owner": "olimorris",
         "repo": "codecompanion.nvim",
-        "rev": "bc5ec92b5f4b8542150a6ae2e77422ec50f440a1",
+        "rev": "b02a7da50e8d1ee473a31f79152dcdf8f7abf5d5",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
     "funky-formatter-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1753902510,
-        "narHash": "sha256-AVwSRC/NQsBp7iBDPQuaG8MNEVo9fBUzKqeNpi/vif0=",
+        "lastModified": 1755897222,
+        "narHash": "sha256-n3gRAQTP7F6QMaOq9iC/ReCB2m0H2SmEWYzYit51Wv0=",
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
-        "rev": "d69fb4eb62cfe85e4842c7104b61449d1a9a5683",
+        "rev": "4a00d71d2eff4f42a03cad6e86b415c8444e5608",
         "type": "github"
       },
       "original": {
@@ -280,11 +280,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754416808,
-        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
+        "lastModified": 1755879220,
+        "narHash": "sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "rev": "3ff4596663c8cbbffe06d863ee4c950bce2c3b78",
         "type": "github"
       },
       "original": {
@@ -340,11 +340,11 @@
     "hop-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754504110,
-        "narHash": "sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA=",
+        "lastModified": 1755878401,
+        "narHash": "sha256-gHRKkqAMrQmpPHEWGETj3KG0NqwCnlTT8z/cNmug/Xc=",
         "owner": "smoka7",
         "repo": "hop.nvim",
-        "rev": "2254e0b3c8054b9ee661c9be3cb201d4b3384d8e",
+        "rev": "707049feaca9ae65abb3696eff9aefc7879e66aa",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754256310,
-        "narHash": "sha256-02sk11tKvsT+R+UMGFmYGehD+sQuBUFiij0T+F/VtOU=",
+        "lastModified": 1755995358,
+        "narHash": "sha256-Eeb2cWi8FNmI0maU/mvnMMOtFFUwnXooS9nylixRT3g=",
         "owner": "dkuettel",
         "repo": "lavish-layouts.nvim",
-        "rev": "6862bce269f99518d93264d8100a91b1e2d93c67",
+        "rev": "e098f4716047fb5116491aa0473dd4b9fbd0bec3",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1755439635,
-        "narHash": "sha256-c7GDrCNRC+2Kgty6pTAdgxDp2mDUoBCI77J3JhH0nss=",
+        "lastModified": 1755985571,
+        "narHash": "sha256-rdg35xq+6vkEs0jTjglMU4YrOwQHGrtYmbrNOE4/dI4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8a97ada3e7c4d8105f4525ba0fe7fdda19bf497f",
+        "rev": "8d63afee33181d9bf05abb65e77cfb72e82b702f",
         "type": "github"
       },
       "original": {
@@ -478,11 +478,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1755380888,
-        "narHash": "sha256-BTPhH335sUyQE8XvrmvtiOpsdDsDMzcKaCiV+sjeGAY=",
+        "lastModified": 1755905887,
+        "narHash": "sha256-sffaIgsOCPqm8254E4EEDaROWh8Y8NRvf1Q4KvYON1k=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5f8d4a248a97b7beb26a097811dce92f1b18e260",
+        "rev": "b9699d5701bb71792bf0c9fdc9dbbea0ec2e8ca1",
         "type": "github"
       },
       "original": {
@@ -509,11 +509,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755268003,
-        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
+        "lastModified": 1755829505,
+        "narHash": "sha256-4/Jd+LkQ2ssw8luQVkqVs9spDBVE6h/u/hC/tzngsPo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
+        "rev": "f937f8ecd1c70efd7e9f90ba13dfb400cf559de4",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1755461203,
-        "narHash": "sha256-pVkQRrrz66Vk16Gfwl8H9X6pJCUXXUmtnN9E8qTLkcs=",
+        "lastModified": 1756050453,
+        "narHash": "sha256-GNQg7/W5lAunKfj95Oaa6u02jLfQX8QCtydRsmKSLXA=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "782dda984da54e465dcc142544133606139d0306",
+        "rev": "aaa807fb2ea8d3caf41c153a174c6b7e472a8428",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'auspicious-autosave-nvim':
    'github:dkuettel/auspicious-autosave.nvim/a19edaf5619a1499c170b3479f9970761fa64f41?narHash=sha256-130aVlInsFwnw8LD5vXVRUp6b3VCzWOzVt640T/%2BDrs%3D' (2025-06-29)
  → 'github:dkuettel/auspicious-autosave.nvim/a3d47ad721d6ac6bfe585174dc95709cc2c48c08?narHash=sha256-ZN2jRDuotQEboGE%2BAtAGAL2iUGKeQ9GVqSELoIAP4GM%3D' (2025-08-23)
• Updated input 'codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/bc5ec92b5f4b8542150a6ae2e77422ec50f440a1?narHash=sha256-RDyps9haPW/QRk13Mw0erv1vRjFm9g3PgjJOV1xZtnE%3D' (2025-08-16)
  → 'github:olimorris/codecompanion.nvim/b02a7da50e8d1ee473a31f79152dcdf8f7abf5d5?narHash=sha256-B1oSN5TjmkRmihH6pDwjuFExz3j/3QIfkHEpYblYvLI%3D' (2025-08-23)
• Updated input 'funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/d69fb4eb62cfe85e4842c7104b61449d1a9a5683?narHash=sha256-AVwSRC/NQsBp7iBDPQuaG8MNEVo9fBUzKqeNpi/vif0%3D' (2025-07-30)
  → 'github:dkuettel/funky-formatter.nvim/4a00d71d2eff4f42a03cad6e86b415c8444e5608?narHash=sha256-n3gRAQTP7F6QMaOq9iC/ReCB2m0H2SmEWYzYit51Wv0%3D' (2025-08-22)
• Updated input 'hop-nvim':
    'github:smoka7/hop.nvim/2254e0b3c8054b9ee661c9be3cb201d4b3384d8e?narHash=sha256-gu9nOdo58V5t/WSe6Mbl4LY0g8VBH0R7fgArqv0WsyA%3D' (2025-08-06)
  → 'github:smoka7/hop.nvim/707049feaca9ae65abb3696eff9aefc7879e66aa?narHash=sha256-gHRKkqAMrQmpPHEWGETj3KG0NqwCnlTT8z/cNmug/Xc%3D' (2025-08-22)
• Updated input 'lavish-layouts-nvim':
    'github:dkuettel/lavish-layouts.nvim/6862bce269f99518d93264d8100a91b1e2d93c67?narHash=sha256-02sk11tKvsT%2BR%2BUMGFmYGehD%2BsQuBUFiij0T%2BF/VtOU%3D' (2025-08-03)
  → 'github:dkuettel/lavish-layouts.nvim/e098f4716047fb5116491aa0473dd4b9fbd0bec3?narHash=sha256-Eeb2cWi8FNmI0maU/mvnMMOtFFUwnXooS9nylixRT3g%3D' (2025-08-24)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/8a97ada3e7c4d8105f4525ba0fe7fdda19bf497f?narHash=sha256-c7GDrCNRC%2B2Kgty6pTAdgxDp2mDUoBCI77J3JhH0nss%3D' (2025-08-17)
  → 'github:nix-community/neovim-nightly-overlay/8d63afee33181d9bf05abb65e77cfb72e82b702f?narHash=sha256-rdg35xq%2B6vkEs0jTjglMU4YrOwQHGrtYmbrNOE4/dI4%3D' (2025-08-23)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/9c52372878df6911f9afc1e2a1391f55e4dfc864?narHash=sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef%2B6fRcofA%3D' (2025-08-05)
  → 'github:cachix/git-hooks.nix/3ff4596663c8cbbffe06d863ee4c950bce2c3b78?narHash=sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc%3D' (2025-08-22)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/5f8d4a248a97b7beb26a097811dce92f1b18e260?narHash=sha256-BTPhH335sUyQE8XvrmvtiOpsdDsDMzcKaCiV%2BsjeGAY%3D' (2025-08-16)
  → 'github:neovim/neovim/b9699d5701bb71792bf0c9fdc9dbbea0ec2e8ca1?narHash=sha256-sffaIgsOCPqm8254E4EEDaROWh8Y8NRvf1Q4KvYON1k%3D' (2025-08-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/32f313e49e42f715491e1ea7b306a87c16fe0388?narHash=sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w%3D' (2025-08-15)
  → 'github:nixos/nixpkgs/f937f8ecd1c70efd7e9f90ba13dfb400cf559de4?narHash=sha256-4/Jd%2BLkQ2ssw8luQVkqVs9spDBVE6h/u/hC/tzngsPo%3D' (2025-08-22)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/782dda984da54e465dcc142544133606139d0306?narHash=sha256-pVkQRrrz66Vk16Gfwl8H9X6pJCUXXUmtnN9E8qTLkcs%3D' (2025-08-17)
  → 'github:neovim/nvim-lspconfig/aaa807fb2ea8d3caf41c153a174c6b7e472a8428?narHash=sha256-GNQg7/W5lAunKfj95Oaa6u02jLfQX8QCtydRsmKSLXA%3D' (2025-08-24)

```

</p></details>

 - Updated input [`funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [`d69fb4eb` ➡️ `4a00d71d`](https://github.com/dkuettel/funky-formatter.nvim/compare/d69fb4eb62cfe85e4842c7104b61449d1a9a5683...4a00d71d2eff4f42a03cad6e86b415c8444e5608) <sub>(2025-07-30 to 2025-08-22)</sub>
 - Updated input [`codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [`bc5ec92b` ➡️ `b02a7da5`](https://github.com/olimorris/codecompanion.nvim/compare/bc5ec92b5f4b8542150a6ae2e77422ec50f440a1...b02a7da50e8d1ee473a31f79152dcdf8f7abf5d5) <sub>(2025-08-16 to 2025-08-23)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`8a97ada3` ➡️ `8d63afee`](https://github.com/nix-community/neovim-nightly-overlay/compare/8a97ada3e7c4d8105f4525ba0fe7fdda19bf497f...8d63afee33181d9bf05abb65e77cfb72e82b702f) <sub>(2025-08-17 to 2025-08-23)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`782dda98` ➡️ `aaa807fb`](https://github.com/neovim/nvim-lspconfig/compare/782dda984da54e465dcc142544133606139d0306...aaa807fb2ea8d3caf41c153a174c6b7e472a8428) <sub>(2025-08-17 to 2025-08-24)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`32f313e4` ➡️ `f937f8ec`](https://github.com/nixos/nixpkgs/compare/32f313e49e42f715491e1ea7b306a87c16fe0388...f937f8ecd1c70efd7e9f90ba13dfb400cf559de4) <sub>(2025-08-15 to 2025-08-22)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`9c523728` ➡️ `3ff45966`](https://github.com/cachix/git-hooks.nix/compare/9c52372878df6911f9afc1e2a1391f55e4dfc864...3ff4596663c8cbbffe06d863ee4c950bce2c3b78) <sub>(2025-08-05 to 2025-08-22)</sub>
 - Updated input [`lavish-layouts-nvim`](https://github.com/dkuettel/lavish-layouts.nvim): [`6862bce2` ➡️ `e098f471`](https://github.com/dkuettel/lavish-layouts.nvim/compare/6862bce269f99518d93264d8100a91b1e2d93c67...e098f4716047fb5116491aa0473dd4b9fbd0bec3) <sub>(2025-08-03 to 2025-08-24)</sub>
 - Updated input [`hop-nvim`](https://github.com/smoka7/hop.nvim): [`2254e0b3` ➡️ `707049fe`](https://github.com/smoka7/hop.nvim/compare/2254e0b3c8054b9ee661c9be3cb201d4b3384d8e...707049feaca9ae65abb3696eff9aefc7879e66aa) <sub>(2025-08-06 to 2025-08-22)</sub>
 - Updated input [`auspicious-autosave-nvim`](https://github.com/dkuettel/auspicious-autosave.nvim): [`a19edaf5` ➡️ `a3d47ad7`](https://github.com/dkuettel/auspicious-autosave.nvim/compare/a19edaf5619a1499c170b3479f9970761fa64f41...a3d47ad721d6ac6bfe585174dc95709cc2c48c08) <sub>(2025-06-29 to 2025-08-23)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`5f8d4a24` ➡️ `b9699d57`](https://github.com/neovim/neovim/compare/5f8d4a248a97b7beb26a097811dce92f1b18e260...b9699d5701bb71792bf0c9fdc9dbbea0ec2e8ca1) <sub>(2025-08-16 to 2025-08-22)</sub>