### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     "codecompanion-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1755937933,
-        "narHash": "sha256-B1oSN5TjmkRmihH6pDwjuFExz3j/3QIfkHEpYblYvLI=",
+        "lastModified": 1756643044,
+        "narHash": "sha256-wyK+QlkxzfB1gbPAE6u9oiVmtXzE1imc7Jbw7tlXmlQ=",
         "owner": "olimorris",
         "repo": "codecompanion.nvim",
-        "rev": "b02a7da50e8d1ee473a31f79152dcdf8f7abf5d5",
+        "rev": "dfd894a3888a87725eb6285b97bb69f7d8e07824",
         "type": "github"
       },
       "original": {
@@ -280,11 +280,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755879220,
-        "narHash": "sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3ff4596663c8cbbffe06d863ee4c950bce2c3b78",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1755985571,
-        "narHash": "sha256-rdg35xq+6vkEs0jTjglMU4YrOwQHGrtYmbrNOE4/dI4=",
+        "lastModified": 1756598714,
+        "narHash": "sha256-QF/yuYgqDeVsNAtoo9tcpMEH7iTljC8pnZ72YlFHsDw=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8d63afee33181d9bf05abb65e77cfb72e82b702f",
+        "rev": "6c06684174406a5c11d1479fa0ab9d3ccc5e08d1",
         "type": "github"
       },
       "original": {
@@ -478,11 +478,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1755905887,
-        "narHash": "sha256-sffaIgsOCPqm8254E4EEDaROWh8Y8NRvf1Q4KvYON1k=",
+        "lastModified": 1756593863,
+        "narHash": "sha256-ZCgJDemS1DqRh9PRcbBYciRfXz7nadLif17mpZQH7u4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b9699d5701bb71792bf0c9fdc9dbbea0ec2e8ca1",
+        "rev": "6a330f893bf15ecab99f1fc796029c7bdba71139",
         "type": "github"
       },
       "original": {
@@ -509,11 +509,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755829505,
-        "narHash": "sha256-4/Jd+LkQ2ssw8luQVkqVs9spDBVE6h/u/hC/tzngsPo=",
+        "lastModified": 1756636162,
+        "narHash": "sha256-mBecwgUTWRgClJYqcF+y4O1bY8PQHqeDpB+zsAn+/zA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f937f8ecd1c70efd7e9f90ba13dfb400cf559de4",
+        "rev": "37ff64b7108517f8b6ba5705ee5085eac636a249",
         "type": "github"
       },
       "original": {
@@ -542,11 +542,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1756050453,
-        "narHash": "sha256-GNQg7/W5lAunKfj95Oaa6u02jLfQX8QCtydRsmKSLXA=",
+        "lastModified": 1756661704,
+        "narHash": "sha256-VklNqxair0LSzUwIZlc3lUqjMMWTS6vOKF5F99nm88s=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "aaa807fb2ea8d3caf41c153a174c6b7e472a8428",
+        "rev": "5f550bbb4d58bb2bfbbed4633fc69c3f0eccaf3a",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754847726,
-        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
+        "lastModified": 1755934250,
+        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
+        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754884337,
-        "narHash": "sha256-Zftd4xFYdCtof6IusN+E079yY2oMTNhJ/yznvLiiur0=",
+        "lastModified": 1756444643,
+        "narHash": "sha256-y4gwFphBaWRbIPR4mf/HUtMchoVQqhcvxw/jTKJgRAg=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "c2599a81ecabaae07c49ff9b45dcd032a8d90f1a",
+        "rev": "f66cdfef5e84112045b9ebc3119fee9bddb3c687",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'codecompanion-nvim':
    'github:olimorris/codecompanion.nvim/b02a7da50e8d1ee473a31f79152dcdf8f7abf5d5?narHash=sha256-B1oSN5TjmkRmihH6pDwjuFExz3j/3QIfkHEpYblYvLI%3D' (2025-08-23)
  → 'github:olimorris/codecompanion.nvim/dfd894a3888a87725eb6285b97bb69f7d8e07824?narHash=sha256-wyK%2BQlkxzfB1gbPAE6u9oiVmtXzE1imc7Jbw7tlXmlQ%3D' (2025-08-31)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/8d63afee33181d9bf05abb65e77cfb72e82b702f?narHash=sha256-rdg35xq%2B6vkEs0jTjglMU4YrOwQHGrtYmbrNOE4/dI4%3D' (2025-08-23)
  → 'github:nix-community/neovim-nightly-overlay/6c06684174406a5c11d1479fa0ab9d3ccc5e08d1?narHash=sha256-QF/yuYgqDeVsNAtoo9tcpMEH7iTljC8pnZ72YlFHsDw%3D' (2025-08-31)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/3ff4596663c8cbbffe06d863ee4c950bce2c3b78?narHash=sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc%3D' (2025-08-22)
  → 'github:cachix/git-hooks.nix/e891a93b193fcaf2fc8012d890dc7f0befe86ec2?narHash=sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs%3D' (2025-08-23)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/b9699d5701bb71792bf0c9fdc9dbbea0ec2e8ca1?narHash=sha256-sffaIgsOCPqm8254E4EEDaROWh8Y8NRvf1Q4KvYON1k%3D' (2025-08-22)
  → 'github:neovim/neovim/6a330f893bf15ecab99f1fc796029c7bdba71139?narHash=sha256-ZCgJDemS1DqRh9PRcbBYciRfXz7nadLif17mpZQH7u4%3D' (2025-08-30)
• Updated input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/7d81f6fb2e19bf84f1c65135d1060d829fae2408?narHash=sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl%2BV/PsmIiJREG4rE%3D' (2025-08-10)
  → 'github:numtide/treefmt-nix/74e1a52d5bd9430312f8d1b8b0354c92c17453e5?narHash=sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU%3D' (2025-08-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f937f8ecd1c70efd7e9f90ba13dfb400cf559de4?narHash=sha256-4/Jd%2BLkQ2ssw8luQVkqVs9spDBVE6h/u/hC/tzngsPo%3D' (2025-08-22)
  → 'github:nixos/nixpkgs/37ff64b7108517f8b6ba5705ee5085eac636a249?narHash=sha256-mBecwgUTWRgClJYqcF%2By4O1bY8PQHqeDpB%2BzsAn%2B/zA%3D' (2025-08-31)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/aaa807fb2ea8d3caf41c153a174c6b7e472a8428?narHash=sha256-GNQg7/W5lAunKfj95Oaa6u02jLfQX8QCtydRsmKSLXA%3D' (2025-08-24)
  → 'github:neovim/nvim-lspconfig/5f550bbb4d58bb2bfbbed4633fc69c3f0eccaf3a?narHash=sha256-VklNqxair0LSzUwIZlc3lUqjMMWTS6vOKF5F99nm88s%3D' (2025-08-31)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/c2599a81ecabaae07c49ff9b45dcd032a8d90f1a?narHash=sha256-Zftd4xFYdCtof6IusN%2BE079yY2oMTNhJ/yznvLiiur0%3D' (2025-08-11)
  → 'github:nvim-tree/nvim-web-devicons/f66cdfef5e84112045b9ebc3119fee9bddb3c687?narHash=sha256-y4gwFphBaWRbIPR4mf/HUtMchoVQqhcvxw/jTKJgRAg%3D' (2025-08-29)

```

</p></details>

 - Updated input [`codecompanion-nvim`](https://github.com/olimorris/codecompanion.nvim): [`b02a7da5` ➡️ `dfd894a3`](https://github.com/olimorris/codecompanion.nvim/compare/b02a7da50e8d1ee473a31f79152dcdf8f7abf5d5...dfd894a3888a87725eb6285b97bb69f7d8e07824) <sub>(2025-08-23 to 2025-08-31)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`8d63afee` ➡️ `6c066841`](https://github.com/nix-community/neovim-nightly-overlay/compare/8d63afee33181d9bf05abb65e77cfb72e82b702f...6c06684174406a5c11d1479fa0ab9d3ccc5e08d1) <sub>(2025-08-23 to 2025-08-31)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`aaa807fb` ➡️ `5f550bbb`](https://github.com/neovim/nvim-lspconfig/compare/aaa807fb2ea8d3caf41c153a174c6b7e472a8428...5f550bbb4d58bb2bfbbed4633fc69c3f0eccaf3a) <sub>(2025-08-24 to 2025-08-31)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`f937f8ec` ➡️ `37ff64b7`](https://github.com/nixos/nixpkgs/compare/f937f8ecd1c70efd7e9f90ba13dfb400cf559de4...37ff64b7108517f8b6ba5705ee5085eac636a249) <sub>(2025-08-22 to 2025-08-31)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3ff45966` ➡️ `e891a93b`](https://github.com/cachix/git-hooks.nix/compare/3ff4596663c8cbbffe06d863ee4c950bce2c3b78...e891a93b193fcaf2fc8012d890dc7f0befe86ec2) <sub>(2025-08-22 to 2025-08-23)</sub>
 - Updated input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`7d81f6fb` ➡️ `74e1a52d`](https://github.com/numtide/treefmt-nix/compare/7d81f6fb2e19bf84f1c65135d1060d829fae2408...74e1a52d5bd9430312f8d1b8b0354c92c17453e5) <sub>(2025-08-10 to 2025-08-23)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`c2599a81` ➡️ `f66cdfef`](https://github.com/nvim-tree/nvim-web-devicons/compare/c2599a81ecabaae07c49ff9b45dcd032a8d90f1a...f66cdfef5e84112045b9ebc3119fee9bddb3c687) <sub>(2025-08-11 to 2025-08-29)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`b9699d57` ➡️ `6a330f89`](https://github.com/neovim/neovim/compare/b9699d5701bb71792bf0c9fdc9dbbea0ec2e8ca1...6a330f893bf15ecab99f1fc796029c7bdba71139) <sub>(2025-08-22 to 2025-08-30)</sub>