### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -136,11 +136,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754037237,
-        "narHash": "sha256-JhTqTGQfIryJ7MElcOGOfb48uaNDnd9RM9Fl1Fs4QV0=",
+        "lastModified": 1756990415,
+        "narHash": "sha256-5FsUVPy8pAiwBh3c+bPDMtypFEHj6qIwGQIo3hjqV4M=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "de10d8414235b0a8cabfeba60d07c24304e71f5c",
+        "rev": "21f74f7ba8c49f95f9d7c8293b147c2901dd2d3a",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1756598714,
-        "narHash": "sha256-QF/yuYgqDeVsNAtoo9tcpMEH7iTljC8pnZ72YlFHsDw=",
+        "lastModified": 1757230098,
+        "narHash": "sha256-MSw+IU56NbE+U0vSxn/Gwg6eIvl4IJqiy20QOg9SAL4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "6c06684174406a5c11d1479fa0ab9d3ccc5e08d1",
+        "rev": "db6e74196727c16d825a2a6f076b1817b7dc668d",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1756593863,
-        "narHash": "sha256-ZCgJDemS1DqRh9PRcbBYciRfXz7nadLif17mpZQH7u4=",
+        "lastModified": 1757200352,
+        "narHash": "sha256-qtWORsM/mj6NtWziW8PE+VYNQnLj4VTtV6ZUaVSjMio=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6a330f893bf15ecab99f1fc796029c7bdba71139",
+        "rev": "21f2c2b19c40882dc6985f87a2e3527c60e3cfaa",
         "type": "github"
       },
       "original": {
@@ -493,11 +493,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756636162,
-        "narHash": "sha256-mBecwgUTWRgClJYqcF+y4O1bY8PQHqeDpB+zsAn+/zA=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "37ff64b7108517f8b6ba5705ee5085eac636a249",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1756661704,
-        "narHash": "sha256-VklNqxair0LSzUwIZlc3lUqjMMWTS6vOKF5F99nm88s=",
+        "lastModified": 1757261721,
+        "narHash": "sha256-ADnSGO1R+RBGkKzu5S/DGdTIe8Fu84nEUHiLIQuq08I=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "5f550bbb4d58bb2bfbbed4633fc69c3f0eccaf3a",
+        "rev": "c8b90ae5cbe21d547b342b05c9266dcb8ca0de8f",
         "type": "github"
       },
       "original": {
@@ -761,11 +761,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755934250,
-        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
         "type": "github"
       },
       "original": {
@@ -802,11 +802,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1756444643,
-        "narHash": "sha256-y4gwFphBaWRbIPR4mf/HUtMchoVQqhcvxw/jTKJgRAg=",
+        "lastModified": 1756936794,
+        "narHash": "sha256-2Q6ZZQj5HFXTw1YwX3ibdGOTwfbfPUBbcPOsuBUpSjc=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "f66cdfef5e84112045b9ebc3119fee9bddb3c687",
+        "rev": "6e51ca170563330e063720449c21f43e27ca0bc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/de10d8414235b0a8cabfeba60d07c24304e71f5c?narHash=sha256-JhTqTGQfIryJ7MElcOGOfb48uaNDnd9RM9Fl1Fs4QV0%3D' (2025-08-01)
  → 'github:L3MON4D3/LuaSnip/21f74f7ba8c49f95f9d7c8293b147c2901dd2d3a?narHash=sha256-5FsUVPy8pAiwBh3c%2BbPDMtypFEHj6qIwGQIo3hjqV4M%3D' (2025-09-04)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/6c06684174406a5c11d1479fa0ab9d3ccc5e08d1?narHash=sha256-QF/yuYgqDeVsNAtoo9tcpMEH7iTljC8pnZ72YlFHsDw%3D' (2025-08-31)
  → 'github:nix-community/neovim-nightly-overlay/db6e74196727c16d825a2a6f076b1817b7dc668d?narHash=sha256-MSw%2BIU56NbE%2BU0vSxn/Gwg6eIvl4IJqiy20QOg9SAL4%3D' (2025-09-07)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
  → 'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751?narHash=sha256-%2BuWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw%3D' (2025-09-01)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/6a330f893bf15ecab99f1fc796029c7bdba71139?narHash=sha256-ZCgJDemS1DqRh9PRcbBYciRfXz7nadLif17mpZQH7u4%3D' (2025-08-30)
  → 'github:neovim/neovim/21f2c2b19c40882dc6985f87a2e3527c60e3cfaa?narHash=sha256-qtWORsM/mj6NtWziW8PE%2BVYNQnLj4VTtV6ZUaVSjMio%3D' (2025-09-06)
• Updated input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/74e1a52d5bd9430312f8d1b8b0354c92c17453e5?narHash=sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU%3D' (2025-08-23)
  → 'github:numtide/treefmt-nix/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4?narHash=sha256-F1oFfV51AE259I85av%2BMAia221XwMHCOtZCMcZLK2Jk%3D' (2025-08-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/37ff64b7108517f8b6ba5705ee5085eac636a249?narHash=sha256-mBecwgUTWRgClJYqcF%2By4O1bY8PQHqeDpB%2BzsAn%2B/zA%3D' (2025-08-31)
  → 'github:nixos/nixpkgs/ca77296380960cd497a765102eeb1356eb80fed0?narHash=sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao%3D' (2025-09-05)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/5f550bbb4d58bb2bfbbed4633fc69c3f0eccaf3a?narHash=sha256-VklNqxair0LSzUwIZlc3lUqjMMWTS6vOKF5F99nm88s%3D' (2025-08-31)
  → 'github:neovim/nvim-lspconfig/c8b90ae5cbe21d547b342b05c9266dcb8ca0de8f?narHash=sha256-ADnSGO1R%2BRBGkKzu5S/DGdTIe8Fu84nEUHiLIQuq08I%3D' (2025-09-07)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/f66cdfef5e84112045b9ebc3119fee9bddb3c687?narHash=sha256-y4gwFphBaWRbIPR4mf/HUtMchoVQqhcvxw/jTKJgRAg%3D' (2025-08-29)
  → 'github:nvim-tree/nvim-web-devicons/6e51ca170563330e063720449c21f43e27ca0bc1?narHash=sha256-2Q6ZZQj5HFXTw1YwX3ibdGOTwfbfPUBbcPOsuBUpSjc%3D' (2025-09-03)

```

</p></details>

 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`6c066841` ➡️ `db6e7419`](https://github.com/nix-community/neovim-nightly-overlay/compare/6c06684174406a5c11d1479fa0ab9d3ccc5e08d1...db6e74196727c16d825a2a6f076b1817b7dc668d) <sub>(2025-08-31 to 2025-09-07)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`de10d841` ➡️ `21f74f7b`](https://github.com/L3MON4D3/LuaSnip/compare/de10d8414235b0a8cabfeba60d07c24304e71f5c...21f74f7ba8c49f95f9d7c8293b147c2901dd2d3a) <sub>(2025-08-01 to 2025-09-04)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`5f550bbb` ➡️ `c8b90ae5`](https://github.com/neovim/nvim-lspconfig/compare/5f550bbb4d58bb2bfbbed4633fc69c3f0eccaf3a...c8b90ae5cbe21d547b342b05c9266dcb8ca0de8f) <sub>(2025-08-31 to 2025-09-07)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`37ff64b7` ➡️ `ca772963`](https://github.com/nixos/nixpkgs/compare/37ff64b7108517f8b6ba5705ee5085eac636a249...ca77296380960cd497a765102eeb1356eb80fed0) <sub>(2025-08-31 to 2025-09-05)</sub>
 - Updated input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`74e1a52d` ➡️ `1aabc6c0`](https://github.com/numtide/treefmt-nix/compare/74e1a52d5bd9430312f8d1b8b0354c92c17453e5...1aabc6c05ccbcbf4a635fb7a90400e44282f61c4) <sub>(2025-08-23 to 2025-08-31)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`f66cdfef` ➡️ `6e51ca17`](https://github.com/nvim-tree/nvim-web-devicons/compare/f66cdfef5e84112045b9ebc3119fee9bddb3c687...6e51ca170563330e063720449c21f43e27ca0bc1) <sub>(2025-08-29 to 2025-09-03)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`6a330f89` ➡️ `21f2c2b1`](https://github.com/neovim/neovim/compare/6a330f893bf15ecab99f1fc796029c7bdba71139...21f2c2b19c40882dc6985f87a2e3527c60e3cfaa) <sub>(2025-08-30 to 2025-09-06)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`af66ad14` ➡️ `45242719`](https://github.com/hercules-ci/flake-parts/compare/af66ad14b28a127c5c0f3bbb298218fc63528a18...4524271976b625a4a605beefd893f270620fd751) <sub>(2025-08-06 to 2025-09-01)</sub>