### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -264,11 +264,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757588530,
-        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755233722,
-        "narHash": "sha256-AavrbMltJKcC2Fx0lfJoZfmy7g87ebXU0ddVenhajLA=",
+        "lastModified": 1758022363,
+        "narHash": "sha256-ENUhCRWgSX4ni751HieNuQoq06dJvApV/Nm89kh+/A0=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "99e03e72e3f7e13506f80ef9ebaedccb929d84d0",
+        "rev": "1a3667d33e247ad35ca250698d63f49a5453d824",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
     "lspkind-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1733408701,
-        "narHash": "sha256-OCvKUBGuzwy8OWOL1x3Z3fo+0+GyBMI9TX41xSveqvE=",
+        "lastModified": 1758179657,
+        "narHash": "sha256-TVKYttrJrEgKfQaEsVGDQH/1i5vr0B3sJIJ4wtQWzns=",
         "owner": "onsails",
         "repo": "lspkind.nvim",
-        "rev": "d79a1c3299ad0ef94e255d045bed9fa26025dab6",
+        "rev": "3ddd1b4edefa425fda5a9f95a4f25578727c0bb3",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1756990415,
-        "narHash": "sha256-5FsUVPy8pAiwBh3c+bPDMtypFEHj6qIwGQIo3hjqV4M=",
+        "lastModified": 1757956796,
+        "narHash": "sha256-L2Wn+VqUpwi43bs+EhXL8j9eQCI13tNONFnCdyRl/Tg=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "21f74f7ba8c49f95f9d7c8293b147c2901dd2d3a",
+        "rev": "b3104910bb5ebf40492aadffae18f2528fa757d9",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1757808376,
-        "narHash": "sha256-bBlkNzJkt8OiaMcoRNlZM1dViUcXViuaqwpqxK+xK+E=",
+        "lastModified": 1758413131,
+        "narHash": "sha256-U/CuBYYUn7Zkzjdjzyu/J9dsMJIMWkgS9zzTX7ucV4s=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "7ef746f86fb9e35edc54809601f58a3b4b0b2c81",
+        "rev": "8ed1dd5718108863216d0a1815f64c53000ca96a",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1757806386,
-        "narHash": "sha256-32vMFpPcSLk8llBvUN+8UpEdQFByR9mivEgK7CC+PUo=",
+        "lastModified": 1758411314,
+        "narHash": "sha256-q0rJAfI7jWW8wJ48dOOiQyWws9A5hHT6Jh9Lq0Q39Cs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "68f40386ed8cf813a7ae8443628b950e7707dc3e",
+        "rev": "f91d416403e923ba9c89f663a6acca80f5ace4ad",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757746433,
-        "narHash": "sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn+odUBTaindgiziY=",
+        "lastModified": 1758446476,
+        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6d7ec06d6868ac6d94c371458fc2391ded9ff13d",
+        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1757630363,
-        "narHash": "sha256-KQSbyXZdezNWXVROZ6QqP/oJeyoqa5twmxfWFsjdGRk=",
+        "lastModified": 1758488643,
+        "narHash": "sha256-jvVjSCAtxgRqrQOJuRrvLR0AON0gVgMzpwN070vTNHs=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "d89f4891f0720cd2598e4bdd60010d8784b2ac8a",
+        "rev": "a13a12861d29fe07b3e5660136baa5cd40751612",
         "type": "github"
       },
       "original": {
@@ -744,11 +744,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756662192,
-        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "lastModified": 1758206697,
+        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'lspkind-nvim':
    'github:onsails/lspkind.nvim/d79a1c3299ad0ef94e255d045bed9fa26025dab6?narHash=sha256-OCvKUBGuzwy8OWOL1x3Z3fo%2B0%2BGyBMI9TX41xSveqvE%3D' (2024-12-05)
  → 'github:onsails/lspkind.nvim/3ddd1b4edefa425fda5a9f95a4f25578727c0bb3?narHash=sha256-TVKYttrJrEgKfQaEsVGDQH/1i5vr0B3sJIJ4wtQWzns%3D' (2025-09-18)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/21f74f7ba8c49f95f9d7c8293b147c2901dd2d3a?narHash=sha256-5FsUVPy8pAiwBh3c%2BbPDMtypFEHj6qIwGQIo3hjqV4M%3D' (2025-09-04)
  → 'github:L3MON4D3/LuaSnip/b3104910bb5ebf40492aadffae18f2528fa757d9?narHash=sha256-L2Wn%2BVqUpwi43bs%2BEhXL8j9eQCI13tNONFnCdyRl/Tg%3D' (2025-09-15)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/7ef746f86fb9e35edc54809601f58a3b4b0b2c81?narHash=sha256-bBlkNzJkt8OiaMcoRNlZM1dViUcXViuaqwpqxK%2BxK%2BE%3D' (2025-09-14)
  → 'github:nix-community/neovim-nightly-overlay/8ed1dd5718108863216d0a1815f64c53000ca96a?narHash=sha256-U/CuBYYUn7Zkzjdjzyu/J9dsMJIMWkgS9zzTX7ucV4s%3D' (2025-09-21)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/b084b2c2b6bc23e83bbfe583b03664eb0b18c411?narHash=sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U%3D' (2025-09-11)
  → 'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b?narHash=sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo%3D' (2025-09-17)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/99e03e72e3f7e13506f80ef9ebaedccb929d84d0?narHash=sha256-AavrbMltJKcC2Fx0lfJoZfmy7g87ebXU0ddVenhajLA%3D' (2025-08-15)
  → 'github:hercules-ci/hercules-ci-effects/1a3667d33e247ad35ca250698d63f49a5453d824?narHash=sha256-ENUhCRWgSX4ni751HieNuQoq06dJvApV/Nm89kh%2B/A0%3D' (2025-09-16)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/68f40386ed8cf813a7ae8443628b950e7707dc3e?narHash=sha256-32vMFpPcSLk8llBvUN%2B8UpEdQFByR9mivEgK7CC%2BPUo%3D' (2025-09-13)
  → 'github:neovim/neovim/f91d416403e923ba9c89f663a6acca80f5ace4ad?narHash=sha256-q0rJAfI7jWW8wJ48dOOiQyWws9A5hHT6Jh9Lq0Q39Cs%3D' (2025-09-20)
• Updated input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4?narHash=sha256-F1oFfV51AE259I85av%2BMAia221XwMHCOtZCMcZLK2Jk%3D' (2025-08-31)
  → 'github:numtide/treefmt-nix/128222dc911b8e2e18939537bed1762b7f3a04aa?narHash=sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0%3D' (2025-09-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6d7ec06d6868ac6d94c371458fc2391ded9ff13d?narHash=sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn%2BodUBTaindgiziY%3D' (2025-09-13)
  → 'github:nixos/nixpkgs/a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0?narHash=sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto%2BdxG4mBo%3D' (2025-09-21)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/d89f4891f0720cd2598e4bdd60010d8784b2ac8a?narHash=sha256-KQSbyXZdezNWXVROZ6QqP/oJeyoqa5twmxfWFsjdGRk%3D' (2025-09-11)
  → 'github:neovim/nvim-lspconfig/a13a12861d29fe07b3e5660136baa5cd40751612?narHash=sha256-jvVjSCAtxgRqrQOJuRrvLR0AON0gVgMzpwN070vTNHs%3D' (2025-09-21)

```

</p></details>

 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`7ef746f8` ➡️ `8ed1dd57`](https://github.com/nix-community/neovim-nightly-overlay/compare/7ef746f86fb9e35edc54809601f58a3b4b0b2c81...8ed1dd5718108863216d0a1815f64c53000ca96a) <sub>(2025-09-14 to 2025-09-21)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`21f74f7b` ➡️ `b3104910`](https://github.com/L3MON4D3/LuaSnip/compare/21f74f7ba8c49f95f9d7c8293b147c2901dd2d3a...b3104910bb5ebf40492aadffae18f2528fa757d9) <sub>(2025-09-04 to 2025-09-15)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`d89f4891` ➡️ `a13a1286`](https://github.com/neovim/nvim-lspconfig/compare/d89f4891f0720cd2598e4bdd60010d8784b2ac8a...a13a12861d29fe07b3e5660136baa5cd40751612) <sub>(2025-09-11 to 2025-09-21)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`99e03e72` ➡️ `1a3667d3`](https://github.com/hercules-ci/hercules-ci-effects/compare/99e03e72e3f7e13506f80ef9ebaedccb929d84d0...1a3667d33e247ad35ca250698d63f49a5453d824) <sub>(2025-08-15 to 2025-09-16)</sub>
 - Updated input [`lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [`d79a1c32` ➡️ `3ddd1b4e`](https://github.com/onsails/lspkind.nvim/compare/d79a1c3299ad0ef94e255d045bed9fa26025dab6...3ddd1b4edefa425fda5a9f95a4f25578727c0bb3) <sub>(2024-12-05 to 2025-09-18)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6d7ec06d` ➡️ `a1f79a17`](https://github.com/nixos/nixpkgs/compare/6d7ec06d6868ac6d94c371458fc2391ded9ff13d...a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0) <sub>(2025-09-13 to 2025-09-21)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`b084b2c2` ➡️ `54df955a`](https://github.com/cachix/git-hooks.nix/compare/b084b2c2b6bc23e83bbfe583b03664eb0b18c411...54df955a695a84cd47d4a43e08e1feaf90b1fd9b) <sub>(2025-09-11 to 2025-09-17)</sub>
 - Updated input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`1aabc6c0` ➡️ `128222dc`](https://github.com/numtide/treefmt-nix/compare/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4...128222dc911b8e2e18939537bed1762b7f3a04aa) <sub>(2025-08-31 to 2025-09-18)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`68f40386` ➡️ `f91d4164`](https://github.com/neovim/neovim/compare/68f40386ed8cf813a7ae8443628b950e7707dc3e...f91d416403e923ba9c89f663a6acca80f5ace4ad) <sub>(2025-09-13 to 2025-09-20)</sub>