### PR TITLE
flake: update flake.lock

### DIFF
--- a/config/lua/yi/formatter.lua
+++ b/config/lua/yi/formatter.lua
@@ -7,66 +7,26 @@ end
 
 function M.setup()
     local formatter = require("funky-formatter")
+    local c = formatter.configs
+    local from_cmds = formatter.from_cmds
+    local path_token = formatter.path_token
+
     formatter.setup {
-        -- TODO was pyformat
-        python = function(path)
-            path = vim.fn.shellescape(path)
-            return {
-                "zsh",
-                "-c",
-                "ruff check --fix-only --select I --silent " .. path .. " | ruff format " .. path,
-            }
-        end,
-        lua = function(path)
-            return { "stylua", "--search-parent-directories", path }
-        end,
-        json = function(path)
-            return { "jq", ".", path }
-        end,
-        yaml = function(path)
-            return { "prettier", "--parser", "yaml", path }
-        end,
-        html = function(path)
-            return { "prettier", "--parser", "html", path }
-        end,
-        css = function(path)
-            return { "prettier", "--parser", "css", path }
-        end,
-        graphql = function(path)
-            return { "prettier", "--parser", "graphql", path }
-        end,
-        javascript = function(path)
-            return { "prettier", "--parser", "typescript", path }
-        end,
-        typescript = function(path)
-            return { "prettier", "--parser", "typescript", path }
-        end,
-        typescriptreact = function(path)
-            return { "prettier", "--parser", "typescript", path }
-        end,
-        rust = function(path)
-            return { "rustfmt", path }
-        end,
-        markdown = function(path)
-            return { "prettier", "--parser", "markdown", path }
-        end,
-        gitignore = function(path)
-            return { "env", "-", "LC_ALL=C", "sort", "--unique", path }
-        end,
-        ["requirements.in"] = function(path)
-            return { "env", "-", "LC_ALL=C", "sort", "--unique", path }
-        end,
-        ["requirements-dev.in"] = function(path)
-            return { "env", "-", "LC_ALL=C", "sort", "--unique", path }
-        end,
-        nix = function(path)
-            return { "nixpkgs-fmt", path }
-        end,
-        toml = function(path)
-            -- TODO taplo also has an lsp, nice if we use it for papers notes?
-            -- TODO different defaults for non-nn stuff?
-            return { "taplo", "fmt", "--option", "indent_string=    ", path }
-        end,
+        python = c.python_ruff_ruff,
+        lua = c.lua_stylua,
+        json = c.json_jq,
+        yaml = c.yaml_prettier,
+        html = c.html_prettier,
+        rust = c.rust_rustfmt,
+        gitignore = c.gitignore_sort,
+        nix = c.nix_nixpkgsfmt,
+        toml = c.toml_taplo,
+        css = from_cmds { { "prettier", "--parser", "css", path_token } },
+        graphql = from_cmds { { "prettier", "--parser", "graphql", path_token } },
+        javascript = from_cmds { { "prettier", "--parser", "javascript", path_token } },
+        typescript = from_cmds { { "prettier", "--parser", "typescript", path_token } },
+        typescriptreact = from_cmds { { "prettier", "--parser", "typescriptreact", path_token } },
+        markdown = from_cmds { { "prettier", "--parser", "markdown", path_token } },
     }
 end
 

--- a/flake.lock
+++ b/flake.lock
@@ -167,11 +167,11 @@
     "funky-formatter-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1757769155,
-        "narHash": "sha256-Hi9DXSJ0Hw7gbF8TvWs96wNQ+qxs5O1tHHu6WJVsGjw=",
+        "lastModified": 1759063337,
+        "narHash": "sha256-kjMT8e0ePVrWesFjUM2rT4gx7I96esBaxG8Kyjxvud0=",
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
-        "rev": "0ada5a41d45f016c4d0a308b53af37fd46d00858",
+        "rev": "bcd9b889e4c5cc94a67c9285829abafdaf3e2112",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1757769168,
-        "narHash": "sha256-7s9lTlPraBPMwWiy4nVqX+hq+q/8TNfXe4w+4JD1bik=",
+        "lastModified": 1759009132,
+        "narHash": "sha256-kMvgnFzYlRsai+r+vEn8icSYlQzxjHO4iV+Ey2bYyek=",
         "owner": "dkuettel",
         "repo": "lavish-layouts.nvim",
-        "rev": "5bebb3de4f0c98a836661bfd32761202c8901cd8",
+        "rev": "4fb6e3353582b91550e444df1adda338555f28c1",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758446476,
-        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1758488643,
-        "narHash": "sha256-jvVjSCAtxgRqrQOJuRrvLR0AON0gVgMzpwN070vTNHs=",
+        "lastModified": 1758832200,
+        "narHash": "sha256-ymJo2lbKtqovFoqOM5EbKGZ4f3nIRGTEVYy8WC+Ui7o=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a13a12861d29fe07b3e5660136baa5cd40751612",
+        "rev": "336b388c272555d2ae94627a50df4c2f89a5e257",
         "type": "github"
       },
       "original": {
@@ -580,11 +580,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1756936794,
-        "narHash": "sha256-2Q6ZZQj5HFXTw1YwX3ibdGOTwfbfPUBbcPOsuBUpSjc=",
+        "lastModified": 1759026302,
+        "narHash": "sha256-mtj9G+7WPpOPTODs1nniAjfOvPX+6WZ4VqRcHGKsRLQ=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "6e51ca170563330e063720449c21f43e27ca0bc1",
+        "rev": "f6b0920f452bfd7595ee9a9efe5e1ae78e0e2997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/0ada5a41d45f016c4d0a308b53af37fd46d00858?narHash=sha256-Hi9DXSJ0Hw7gbF8TvWs96wNQ%2Bqxs5O1tHHu6WJVsGjw%3D' (2025-09-13)
  → 'github:dkuettel/funky-formatter.nvim/bcd9b889e4c5cc94a67c9285829abafdaf3e2112?narHash=sha256-kjMT8e0ePVrWesFjUM2rT4gx7I96esBaxG8Kyjxvud0%3D' (2025-09-28)
• Updated input 'lavish-layouts-nvim':
    'github:dkuettel/lavish-layouts.nvim/5bebb3de4f0c98a836661bfd32761202c8901cd8?narHash=sha256-7s9lTlPraBPMwWiy4nVqX%2Bhq%2Bq/8TNfXe4w%2B4JD1bik%3D' (2025-09-13)
  → 'github:dkuettel/lavish-layouts.nvim/4fb6e3353582b91550e444df1adda338555f28c1?narHash=sha256-kMvgnFzYlRsai%2Br%2BvEn8icSYlQzxjHO4iV%2BEy2bYyek%3D' (2025-09-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0?narHash=sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto%2BdxG4mBo%3D' (2025-09-21)
  → 'github:nixos/nixpkgs/e9f00bd893984bc8ce46c895c3bf7cac95331127?narHash=sha256-0m27AKv6ka%2Bq270dw48KflE0LwQYrO7Fm4/2//KCVWg%3D' (2025-09-28)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a13a12861d29fe07b3e5660136baa5cd40751612?narHash=sha256-jvVjSCAtxgRqrQOJuRrvLR0AON0gVgMzpwN070vTNHs%3D' (2025-09-21)
  → 'github:neovim/nvim-lspconfig/336b388c272555d2ae94627a50df4c2f89a5e257?narHash=sha256-ymJo2lbKtqovFoqOM5EbKGZ4f3nIRGTEVYy8WC%2BUi7o%3D' (2025-09-25)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/6e51ca170563330e063720449c21f43e27ca0bc1?narHash=sha256-2Q6ZZQj5HFXTw1YwX3ibdGOTwfbfPUBbcPOsuBUpSjc%3D' (2025-09-03)
  → 'github:nvim-tree/nvim-web-devicons/f6b0920f452bfd7595ee9a9efe5e1ae78e0e2997?narHash=sha256-mtj9G%2B7WPpOPTODs1nniAjfOvPX%2B6WZ4VqRcHGKsRLQ%3D' (2025-09-28)

```

</p></details>

 - Updated input [`funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [`0ada5a41` ➡️ `bcd9b889`](https://github.com/dkuettel/funky-formatter.nvim/compare/0ada5a41d45f016c4d0a308b53af37fd46d00858...bcd9b889e4c5cc94a67c9285829abafdaf3e2112) <sub>(2025-09-13 to 2025-09-28)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a13a1286` ➡️ `336b388c`](https://github.com/neovim/nvim-lspconfig/compare/a13a12861d29fe07b3e5660136baa5cd40751612...336b388c272555d2ae94627a50df4c2f89a5e257) <sub>(2025-09-21 to 2025-09-25)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a1f79a17` ➡️ `e9f00bd8`](https://github.com/nixos/nixpkgs/compare/a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0...e9f00bd893984bc8ce46c895c3bf7cac95331127) <sub>(2025-09-21 to 2025-09-28)</sub>
 - Updated input [`lavish-layouts-nvim`](https://github.com/dkuettel/lavish-layouts.nvim): [`5bebb3de` ➡️ `4fb6e335`](https://github.com/dkuettel/lavish-layouts.nvim/compare/5bebb3de4f0c98a836661bfd32761202c8901cd8...4fb6e3353582b91550e444df1adda338555f28c1) <sub>(2025-09-13 to 2025-09-27)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`6e51ca17` ➡️ `f6b0920f`](https://github.com/nvim-tree/nvim-web-devicons/compare/6e51ca170563330e063720449c21f43e27ca0bc1...f6b0920f452bfd7595ee9a9efe5e1ae78e0e2997) <sub>(2025-09-03 to 2025-09-28)</sub>