### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
         "type": "github"
       },
       "original": {
@@ -188,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1759523803,
+        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
         "type": "github"
       },
       "original": {
@@ -350,11 +350,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1759523803,
+        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1757956796,
-        "narHash": "sha256-L2Wn+VqUpwi43bs+EhXL8j9eQCI13tNONFnCdyRl/Tg=",
+        "lastModified": 1759157591,
+        "narHash": "sha256-sicE0/Vgc03X+Qxqlu5CM7NGd+6FE9RGx6OjZUa6Umw=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "b3104910bb5ebf40492aadffae18f2528fa757d9",
+        "rev": "73813308abc2eaeff2bc0d3f2f79270c491be9d7",
         "type": "github"
       },
       "original": {
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758950882,
-        "narHash": "sha256-s2aVgfHQx9LSqPOLfkny/HaIuVj46VyER8sgq++cRI0=",
+        "lastModified": 1759555628,
+        "narHash": "sha256-2kiwbSoJJxcrsaKI5U6yhAhyviBDWyHE0rBocmW0jag=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "fc9288c539d83adae5356b18dea8187ba380dd56",
+        "rev": "791842c8e19324475876ab0d1107546930982e7a",
         "type": "github"
       },
       "original": {
@@ -592,11 +592,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1758931509,
-        "narHash": "sha256-NFOXeqUwhH+V+XXJP3Z8RRzjulOzokwOPQ2kbDuFvX8=",
+        "lastModified": 1759536427,
+        "narHash": "sha256-jYsR/51FszWZt1Y4WgjqZfjzIs+BLc31pHgwZnT1fS4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "93318bab5ce403a60a694ad1b6219760935553f7",
+        "rev": "fb58686fa7a411ad0818d2c86ee210ccafc2b409",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1758863424,
-        "narHash": "sha256-fYY8JrOuqovlOcXfryf2xiahBPTXHQExFpMIsur69/A=",
+        "lastModified": 1759535609,
+        "narHash": "sha256-UINKl0e0HbazbxjrP5Btv/RXOSPoIFCaLNOwLZ+I714=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a0c60e819df1b4d4ae5ac631d48e874fa1cf9b92",
+        "rev": "b6b80824cc71fb9f32ddf2e9a96205633342827e",
         "type": "github"
       },
       "original": {
@@ -639,11 +639,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759632233,
+        "narHash": "sha256-krgZxGAIIIKFJS+UB0l8do3sYUDWJc75M72tepmVMzE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "d7f52a7a640bc54c7bb414cca603835bf8dd4b10",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1758763312,
-        "narHash": "sha256-puBMviZhYlqOdUUgEmMVJpXqC/ToEqSvkyZ30qQ09xM=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e57b3b16ad8758fd681511a078f35c416a8cc939",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {
@@ -702,11 +702,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1758916627,
-        "narHash": "sha256-fB2ISCc+xn+9hZ6gOsABxSBcsCgLCjbJ5bC6U9bPzQ4=",
+        "lastModified": 1759536663,
+        "narHash": "sha256-hhM8SUI6kQMei5TImFdNQy9EDT8g2hAD161DUtbfAy0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "53614373268559d054c080d070cfc732dbe68ac4",
+        "rev": "27ac93958969b5f3dccd654b402599cf3de633ac",
         "type": "github"
       },
       "original": {
@@ -719,11 +719,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1758832200,
-        "narHash": "sha256-ymJo2lbKtqovFoqOM5EbKGZ4f3nIRGTEVYy8WC+Ui7o=",
+        "lastModified": 1759548517,
+        "narHash": "sha256-K56vjTUkQ/NdA6vq5942zUknPiCUbMByiEW540dR8R0=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "336b388c272555d2ae94627a50df4c2f89a5e257",
+        "rev": "e688b486fe9291f151eae7e5c0b5a5c4ef980847",
         "type": "github"
       },
       "original": {
@@ -861,11 +861,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1759018992,
-        "narHash": "sha256-daJ1BpyPL7DdhLYu2KZw6OmpOylSzCpSwVx6mLjc4Ok=",
+        "lastModified": 1759623626,
+        "narHash": "sha256-Cz4LDzz7v3kBS1mbxZjprogqHFghYr5xMfSN3us2Ltk=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "7c9271934d926969e920f7da932da6ba234b1e5a",
+        "rev": "96a4f5efc7705f613ddd47fb5d1445c172acb213",
         "type": "github"
       },
       "original": {
@@ -1048,11 +1048,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1759026302,
-        "narHash": "sha256-mtj9G+7WPpOPTODs1nniAjfOvPX+6WZ4VqRcHGKsRLQ=",
+        "lastModified": 1759188261,
+        "narHash": "sha256-lVrakFrpIP9lp7sMfMb33KeMPIkcn1qBFVytJzKCfuE=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "f6b0920f452bfd7595ee9a9efe5e1ae78e0e2997",
+        "rev": "b8221e42cf7287c4dcde81f232f58d7b947c210d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/b3104910bb5ebf40492aadffae18f2528fa757d9?narHash=sha256-L2Wn%2BVqUpwi43bs%2BEhXL8j9eQCI13tNONFnCdyRl/Tg%3D' (2025-09-15)
  → 'github:L3MON4D3/LuaSnip/73813308abc2eaeff2bc0d3f2f79270c491be9d7?narHash=sha256-sicE0/Vgc03X%2BQxqlu5CM7NGd%2B6FE9RGx6OjZUa6Umw%3D' (2025-09-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e9f00bd893984bc8ce46c895c3bf7cac95331127?narHash=sha256-0m27AKv6ka%2Bq270dw48KflE0LwQYrO7Fm4/2//KCVWg%3D' (2025-09-28)
  → 'github:nixos/nixpkgs/d7f52a7a640bc54c7bb414cca603835bf8dd4b10?narHash=sha256-krgZxGAIIIKFJS%2BUB0l8do3sYUDWJc75M72tepmVMzE%3D' (2025-10-05)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/336b388c272555d2ae94627a50df4c2f89a5e257?narHash=sha256-ymJo2lbKtqovFoqOM5EbKGZ4f3nIRGTEVYy8WC%2BUi7o%3D' (2025-09-25)
  → 'github:neovim/nvim-lspconfig/e688b486fe9291f151eae7e5c0b5a5c4ef980847?narHash=sha256-K56vjTUkQ/NdA6vq5942zUknPiCUbMByiEW540dR8R0%3D' (2025-10-04)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/7c9271934d926969e920f7da932da6ba234b1e5a?narHash=sha256-daJ1BpyPL7DdhLYu2KZw6OmpOylSzCpSwVx6mLjc4Ok%3D' (2025-09-28)
  → 'github:mrcjkb/rustaceanvim/96a4f5efc7705f613ddd47fb5d1445c172acb213?narHash=sha256-Cz4LDzz7v3kBS1mbxZjprogqHFghYr5xMfSN3us2Ltk%3D' (2025-10-05)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751?narHash=sha256-%2BuWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw%3D' (2025-09-01)
  → 'github:hercules-ci/flake-parts/758cf7296bee11f1706a574c77d072b8a7baa881?narHash=sha256-wfG0S7pltlYyZTM%2BqqlhJ7GMw2fTF4mLKCIVhLii/4M%3D' (2025-10-01)
• Updated input 'rustacean-nvim/git-hooks':
    'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b?narHash=sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo%3D' (2025-09-17)
  → 'github:cachix/git-hooks.nix/cfc9f7bb163ad8542029d303e599c0f7eee09835?narHash=sha256-PTod9NG%2Bi3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM%3D' (2025-10-03)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/fc9288c539d83adae5356b18dea8187ba380dd56?narHash=sha256-s2aVgfHQx9LSqPOLfkny/HaIuVj46VyER8sgq%2B%2BcRI0%3D' (2025-09-27)
  → 'github:nvim-neorocks/neorocks/791842c8e19324475876ab0d1107546930982e7a?narHash=sha256-2kiwbSoJJxcrsaKI5U6yhAhyviBDWyHE0rBocmW0jag%3D' (2025-10-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/93318bab5ce403a60a694ad1b6219760935553f7?narHash=sha256-NFOXeqUwhH%2BV%2BXXJP3Z8RRzjulOzokwOPQ2kbDuFvX8%3D' (2025-09-27)
  → 'github:nix-community/neovim-nightly-overlay/fb58686fa7a411ad0818d2c86ee210ccafc2b409?narHash=sha256-jYsR/51FszWZt1Y4WgjqZfjzIs%2BBLc31pHgwZnT1fS4%3D' (2025-10-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751?narHash=sha256-%2BuWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw%3D' (2025-09-01)
  → 'github:hercules-ci/flake-parts/758cf7296bee11f1706a574c77d072b8a7baa881?narHash=sha256-wfG0S7pltlYyZTM%2BqqlhJ7GMw2fTF4mLKCIVhLii/4M%3D' (2025-10-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b?narHash=sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo%3D' (2025-09-17)
  → 'github:cachix/git-hooks.nix/cfc9f7bb163ad8542029d303e599c0f7eee09835?narHash=sha256-PTod9NG%2Bi3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM%3D' (2025-10-03)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/a0c60e819df1b4d4ae5ac631d48e874fa1cf9b92?narHash=sha256-fYY8JrOuqovlOcXfryf2xiahBPTXHQExFpMIsur69/A%3D' (2025-09-26)
  → 'github:neovim/neovim/b6b80824cc71fb9f32ddf2e9a96205633342827e?narHash=sha256-UINKl0e0HbazbxjrP5Btv/RXOSPoIFCaLNOwLZ%2BI714%3D' (2025-10-03)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/e57b3b16ad8758fd681511a078f35c416a8cc939?narHash=sha256-puBMviZhYlqOdUUgEmMVJpXqC/ToEqSvkyZ30qQ09xM%3D' (2025-09-25)
  → 'github:NixOS/nixpkgs/dc704e6102e76aad573f63b74c742cd96f8f1e6c?narHash=sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow%3D' (2025-10-02)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/53614373268559d054c080d070cfc732dbe68ac4?narHash=sha256-fB2ISCc%2Bxn%2B9hZ6gOsABxSBcsCgLCjbJ5bC6U9bPzQ4%3D' (2025-09-26)
  → 'github:nixos/nixpkgs/27ac93958969b5f3dccd654b402599cf3de633ac?narHash=sha256-hhM8SUI6kQMei5TImFdNQy9EDT8g2hAD161DUtbfAy0%3D' (2025-10-04)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/f6b0920f452bfd7595ee9a9efe5e1ae78e0e2997?narHash=sha256-mtj9G%2B7WPpOPTODs1nniAjfOvPX%2B6WZ4VqRcHGKsRLQ%3D' (2025-09-28)
  → 'github:nvim-tree/nvim-web-devicons/b8221e42cf7287c4dcde81f232f58d7b947c210d?narHash=sha256-lVrakFrpIP9lp7sMfMb33KeMPIkcn1qBFVytJzKCfuE%3D' (2025-09-29)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`93318bab` ➡️ `fb58686f`](https://github.com/nix-community/neovim-nightly-overlay/compare/93318bab5ce403a60a694ad1b6219760935553f7...fb58686fa7a411ad0818d2c86ee210ccafc2b409) <sub>(2025-09-27 to 2025-10-04)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`7c927193` ➡️ `96a4f5ef`](https://github.com/mrcjkb/rustaceanvim/compare/7c9271934d926969e920f7da932da6ba234b1e5a...96a4f5efc7705f613ddd47fb5d1445c172acb213) <sub>(2025-09-28 to 2025-10-05)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`fc9288c5` ➡️ `791842c8`](https://github.com/nvim-neorocks/neorocks/compare/fc9288c539d83adae5356b18dea8187ba380dd56...791842c8e19324475876ab0d1107546930982e7a) <sub>(2025-09-27 to 2025-10-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`a0c60e81` ➡️ `b6b80824`](https://github.com/neovim/neovim/compare/a0c60e819df1b4d4ae5ac631d48e874fa1cf9b92...b6b80824cc71fb9f32ddf2e9a96205633342827e) <sub>(2025-09-26 to 2025-10-03)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`b3104910` ➡️ `73813308`](https://github.com/L3MON4D3/LuaSnip/compare/b3104910bb5ebf40492aadffae18f2528fa757d9...73813308abc2eaeff2bc0d3f2f79270c491be9d7) <sub>(2025-09-15 to 2025-09-29)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`45242719` ➡️ `758cf729`](https://github.com/hercules-ci/flake-parts/compare/4524271976b625a4a605beefd893f270620fd751...758cf7296bee11f1706a574c77d072b8a7baa881) <sub>(2025-09-01 to 2025-10-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`336b388c` ➡️ `e688b486`](https://github.com/neovim/nvim-lspconfig/compare/336b388c272555d2ae94627a50df4c2f89a5e257...e688b486fe9291f151eae7e5c0b5a5c4ef980847) <sub>(2025-09-25 to 2025-10-04)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`53614373` ➡️ `27ac9395`](https://github.com/nixos/nixpkgs/compare/53614373268559d054c080d070cfc732dbe68ac4...27ac93958969b5f3dccd654b402599cf3de633ac) <sub>(2025-09-26 to 2025-10-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e9f00bd8` ➡️ `d7f52a7a`](https://github.com/nixos/nixpkgs/compare/e9f00bd893984bc8ce46c895c3bf7cac95331127...d7f52a7a640bc54c7bb414cca603835bf8dd4b10) <sub>(2025-09-28 to 2025-10-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`e57b3b16` ➡️ `dc704e61`](https://github.com/NixOS/nixpkgs/compare/e57b3b16ad8758fd681511a078f35c416a8cc939...dc704e6102e76aad573f63b74c742cd96f8f1e6c) <sub>(2025-09-25 to 2025-10-02)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`f6b0920f` ➡️ `b8221e42`](https://github.com/nvim-tree/nvim-web-devicons/compare/f6b0920f452bfd7595ee9a9efe5e1ae78e0e2997...b8221e42cf7287c4dcde81f232f58d7b947c210d) <sub>(2025-09-28 to 2025-09-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`54df955a` ➡️ `cfc9f7bb`](https://github.com/cachix/git-hooks.nix/compare/54df955a695a84cd47d4a43e08e1feaf90b1fd9b...cfc9f7bb163ad8542029d303e599c0f7eee09835) <sub>(2025-09-17 to 2025-10-03)</sub>
 - Updated input [`rustacean-nvim/git-hooks`](https://github.com/cachix/git-hooks.nix): [`54df955a` ➡️ `cfc9f7bb`](https://github.com/cachix/git-hooks.nix/compare/54df955a695a84cd47d4a43e08e1feaf90b1fd9b...cfc9f7bb163ad8542029d303e599c0f7eee09835) <sub>(2025-09-17 to 2025-10-03)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`45242719` ➡️ `758cf729`](https://github.com/hercules-ci/flake-parts/compare/4524271976b625a4a605beefd893f270620fd751...758cf7296bee11f1706a574c77d072b8a7baa881) <sub>(2025-09-01 to 2025-10-01)</sub>