### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775321324,
-        "narHash": "sha256-Ew/gES5NYHPUYzRXSo7+LwvjKdn7BlGNcvAC7hujSPU=",
+        "lastModified": 1775957658,
+        "narHash": "sha256-PHunrG0yd3pDw3c1S9w1AXQx5/1nT68M+mjxT53enmM=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "8811f3f3f4dc09d740c67e9ce399e7a541e2e5b2",
+        "rev": "a905eeebc4e63fdc48b5135d3bf8aea5618fb21c",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775403759,
-        "narHash": "sha256-cGyKiTspHEUx3QwAnV3RfyT+VOXhHLs+NEr17HU34Wo=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e11f7acce6c3469bef9df154d78534fa7ae8b6c",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1775405341,
-        "narHash": "sha256-6ojqQtAGTRN214qI33kd5L0U5nRxWggL1gbEqQf0620=",
+        "lastModified": 1776021290,
+        "narHash": "sha256-y7OgmBs1baqNbLfI80CmGSJOgZi0xcOsJOhyZmsKJP8=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a776085e04f7b15d0b59fae2244df07d98360ab4",
+        "rev": "8a9378a822719346a0288fa004dab302ca3c0a8f",
         "type": "github"
       },
       "original": {
@@ -221,11 +221,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1775222259,
-        "narHash": "sha256-/QSchydTl66OELMpcukR7N0CIpda5ATDKAlwQKEbcP0=",
+        "lastModified": 1775590987,
+        "narHash": "sha256-0H8adz3b0WSW7W1NG+mfJb69/Ag4xK/XCNjqzaP3LsM=",
         "owner": "dkuettel",
         "repo": "ptags.nvim",
-        "rev": "70224fd9b47ba17cc05c7537c5dc0d17e7c18786",
+        "rev": "b737c85e0cd5d3f7d1867508015edace194c4717",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1774941932,
-        "narHash": "sha256-QNBlbeVc7wl8j+K38xfC6ZT4XpGJzylQtateQiZxjBY=",
+        "lastModified": 1775811923,
+        "narHash": "sha256-dncm8Cd4TUMhO+uaRvRsPZngDye3WR16FryuYp0lbMI=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "cfb85dcf7f822b79224e9e6aef9e8c794211b20b",
+        "rev": "f7c673b8e46e8f233ff581d3624a517d33a7e264",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/8811f3f3f4dc09d740c67e9ce399e7a541e2e5b2?narHash=sha256-Ew/gES5NYHPUYzRXSo7%2BLwvjKdn7BlGNcvAC7hujSPU%3D' (2026-04-04)
  → 'github:nvim-lualine/lualine.nvim/a905eeebc4e63fdc48b5135d3bf8aea5618fb21c?narHash=sha256-PHunrG0yd3pDw3c1S9w1AXQx5/1nT68M%2BmjxT53enmM%3D' (2026-04-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5e11f7acce6c3469bef9df154d78534fa7ae8b6c?narHash=sha256-cGyKiTspHEUx3QwAnV3RfyT%2BVOXhHLs%2BNEr17HU34Wo%3D' (2026-04-05)
  → 'github:nixos/nixpkgs/13043924aaa7375ce482ebe2494338e058282925?narHash=sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90%3D' (2026-04-11)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a776085e04f7b15d0b59fae2244df07d98360ab4?narHash=sha256-6ojqQtAGTRN214qI33kd5L0U5nRxWggL1gbEqQf0620%3D' (2026-04-05)
  → 'github:neovim/nvim-lspconfig/8a9378a822719346a0288fa004dab302ca3c0a8f?narHash=sha256-y7OgmBs1baqNbLfI80CmGSJOgZi0xcOsJOhyZmsKJP8%3D' (2026-04-12)
• Updated input 'ptags-nvim':
    'github:dkuettel/ptags.nvim/70224fd9b47ba17cc05c7537c5dc0d17e7c18786?narHash=sha256-/QSchydTl66OELMpcukR7N0CIpda5ATDKAlwQKEbcP0%3D' (2026-04-03)
  → 'github:dkuettel/ptags.nvim/b737c85e0cd5d3f7d1867508015edace194c4717?narHash=sha256-0H8adz3b0WSW7W1NG%2BmfJb69/Ag4xK/XCNjqzaP3LsM%3D' (2026-04-07)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/cfb85dcf7f822b79224e9e6aef9e8c794211b20b?narHash=sha256-QNBlbeVc7wl8j%2BK38xfC6ZT4XpGJzylQtateQiZxjBY%3D' (2026-03-31)
  → 'github:nvim-telescope/telescope.nvim/f7c673b8e46e8f233ff581d3624a517d33a7e264?narHash=sha256-dncm8Cd4TUMhO%2BuaRvRsPZngDye3WR16FryuYp0lbMI%3D' (2026-04-10)

```

</p></details>

 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`8811f3f3` ➡️ `a905eeeb`](https://github.com/nvim-lualine/lualine.nvim/compare/8811f3f3f4dc09d740c67e9ce399e7a541e2e5b2...a905eeebc4e63fdc48b5135d3bf8aea5618fb21c) <sub>(2026-04-04 to 2026-04-12)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5e11f7ac` ➡️ `13043924`](https://github.com/nixos/nixpkgs/compare/5e11f7acce6c3469bef9df154d78534fa7ae8b6c...13043924aaa7375ce482ebe2494338e058282925) <sub>(2026-04-05 to 2026-04-11)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a776085e` ➡️ `8a9378a8`](https://github.com/neovim/nvim-lspconfig/compare/a776085e04f7b15d0b59fae2244df07d98360ab4...8a9378a822719346a0288fa004dab302ca3c0a8f) <sub>(2026-04-05 to 2026-04-12)<sub/>
 - Updated input [`ptags-nvim`](https://github.com/dkuettel/ptags.nvim): [`70224fd9` ➡️ `b737c85e`](https://github.com/dkuettel/ptags.nvim/compare/70224fd9b47ba17cc05c7537c5dc0d17e7c18786...b737c85e0cd5d3f7d1867508015edace194c4717) <sub>(2026-04-03 to 2026-04-07)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`cfb85dcf` ➡️ `f7c673b8`](https://github.com/nvim-telescope/telescope.nvim/compare/cfb85dcf7f822b79224e9e6aef9e8c794211b20b...f7c673b8e46e8f233ff581d3624a517d33a7e264) <sub>(2026-03-31 to 2026-04-10)<sub/>