### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1776021290,
-        "narHash": "sha256-y7OgmBs1baqNbLfI80CmGSJOgZi0xcOsJOhyZmsKJP8=",
+        "lastModified": 1776329745,
+        "narHash": "sha256-RZs2wqVgGy6TNBWZifoj+58gIpNC0kZtt5MiNPQ38+U=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "8a9378a822719346a0288fa004dab302ca3c0a8f",
+        "rev": "4b7fbaa239c5db6b36f424a4521ca9f1a401be33",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775811923,
-        "narHash": "sha256-dncm8Cd4TUMhO+uaRvRsPZngDye3WR16FryuYp0lbMI=",
+        "lastModified": 1776591070,
+        "narHash": "sha256-xU/lozREXuXkjBq8L94sLwyEE6f7k8Q3y0BkjPssB1Y=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "f7c673b8e46e8f233ff581d3624a517d33a7e264",
+        "rev": "028d9a0695a0cc4cfa893889f8c408ed7ccc8adc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/13043924aaa7375ce482ebe2494338e058282925?narHash=sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90%3D' (2026-04-11)
  → 'github:nixos/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b?narHash=sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw%3D' (2026-04-16)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/8a9378a822719346a0288fa004dab302ca3c0a8f?narHash=sha256-y7OgmBs1baqNbLfI80CmGSJOgZi0xcOsJOhyZmsKJP8%3D' (2026-04-12)
  → 'github:neovim/nvim-lspconfig/4b7fbaa239c5db6b36f424a4521ca9f1a401be33?narHash=sha256-RZs2wqVgGy6TNBWZifoj%2B58gIpNC0kZtt5MiNPQ38%2BU%3D' (2026-04-16)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/f7c673b8e46e8f233ff581d3624a517d33a7e264?narHash=sha256-dncm8Cd4TUMhO%2BuaRvRsPZngDye3WR16FryuYp0lbMI%3D' (2026-04-10)
  → 'github:nvim-telescope/telescope.nvim/028d9a0695a0cc4cfa893889f8c408ed7ccc8adc?narHash=sha256-xU/lozREXuXkjBq8L94sLwyEE6f7k8Q3y0BkjPssB1Y%3D' (2026-04-19)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`13043924` ➡️ `b86751bc`](https://github.com/nixos/nixpkgs/compare/13043924aaa7375ce482ebe2494338e058282925...b86751bc4085f48661017fa226dee99fab6c651b) <sub>(2026-04-11 to 2026-04-16)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`8a9378a8` ➡️ `4b7fbaa2`](https://github.com/neovim/nvim-lspconfig/compare/8a9378a822719346a0288fa004dab302ca3c0a8f...4b7fbaa239c5db6b36f424a4521ca9f1a401be33) <sub>(2026-04-12 to 2026-04-16)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`f7c673b8` ➡️ `028d9a06`](https://github.com/nvim-telescope/telescope.nvim/compare/f7c673b8e46e8f233ff581d3624a517d33a7e264...028d9a0695a0cc4cfa893889f8c408ed7ccc8adc) <sub>(2026-04-10 to 2026-04-19)<sub/>