### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1776329745,
-        "narHash": "sha256-RZs2wqVgGy6TNBWZifoj+58gIpNC0kZtt5MiNPQ38+U=",
+        "lastModified": 1777198644,
+        "narHash": "sha256-w21MFUH+44m3uJKm0LrlXe4etp6TgE6P8tJvy4q+Goc=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "4b7fbaa239c5db6b36f424a4521ca9f1a401be33",
+        "rev": "21db1fd40cbcbf1524ae154ab8f394fdf085749a",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1755454338,
-        "narHash": "sha256-7CABjYC4QWFMWY3OybaqRMG5YN/gtBnntJzNeE2UJXs=",
+        "lastModified": 1777221488,
+        "narHash": "sha256-/95BrY/Eiou0BouuCtlGp7NPE5yTjG0uVezxnuzPWZk=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "1d03fa71616fc1d9bf412eb10ce7d08412bd9fd4",
+        "rev": "6593c19f2ff93057562e41a9ee1b22503b7e5e91",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1776591070,
-        "narHash": "sha256-xU/lozREXuXkjBq8L94sLwyEE6f7k8Q3y0BkjPssB1Y=",
+        "lastModified": 1776840800,
+        "narHash": "sha256-ekfqqG44cS13FJ0qQKOCl8bftxF8BSRD5v+wZrCAvb8=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "028d9a0695a0cc4cfa893889f8c408ed7ccc8adc",
+        "rev": "506338434fec5ad19cb1f8d45bf92d66c4917393",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b?narHash=sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw%3D' (2026-04-16)
  → 'github:nixos/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30?narHash=sha256-GMSVw35Q%2B294GlrTUKlx087E31z7KurReQ1YHSKp5iw%3D' (2026-04-23)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/4b7fbaa239c5db6b36f424a4521ca9f1a401be33?narHash=sha256-RZs2wqVgGy6TNBWZifoj%2B58gIpNC0kZtt5MiNPQ38%2BU%3D' (2026-04-16)
  → 'github:neovim/nvim-lspconfig/21db1fd40cbcbf1524ae154ab8f394fdf085749a?narHash=sha256-w21MFUH%2B44m3uJKm0LrlXe4etp6TgE6P8tJvy4q%2BGoc%3D' (2026-04-26)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/1d03fa71616fc1d9bf412eb10ce7d08412bd9fd4?narHash=sha256-7CABjYC4QWFMWY3OybaqRMG5YN/gtBnntJzNeE2UJXs%3D' (2025-08-17)
  → 'github:lima1909/resty.nvim/6593c19f2ff93057562e41a9ee1b22503b7e5e91?narHash=sha256-/95BrY/Eiou0BouuCtlGp7NPE5yTjG0uVezxnuzPWZk%3D' (2026-04-26)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/028d9a0695a0cc4cfa893889f8c408ed7ccc8adc?narHash=sha256-xU/lozREXuXkjBq8L94sLwyEE6f7k8Q3y0BkjPssB1Y%3D' (2026-04-19)
  → 'github:nvim-telescope/telescope.nvim/506338434fec5ad19cb1f8d45bf92d66c4917393?narHash=sha256-ekfqqG44cS13FJ0qQKOCl8bftxF8BSRD5v%2BwZrCAvb8%3D' (2026-04-22)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`b86751bc` ➡️ `01fbdeef`](https://github.com/nixos/nixpkgs/compare/b86751bc4085f48661017fa226dee99fab6c651b...01fbdeef22b76df85ea168fbfe1bfd9e63681b30) <sub>(2026-04-16 to 2026-04-23)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`4b7fbaa2` ➡️ `21db1fd4`](https://github.com/neovim/nvim-lspconfig/compare/4b7fbaa239c5db6b36f424a4521ca9f1a401be33...21db1fd40cbcbf1524ae154ab8f394fdf085749a) <sub>(2026-04-16 to 2026-04-26)<sub/>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`1d03fa71` ➡️ `6593c19f`](https://github.com/lima1909/resty.nvim/compare/1d03fa71616fc1d9bf412eb10ce7d08412bd9fd4...6593c19f2ff93057562e41a9ee1b22503b7e5e91) <sub>(2025-08-17 to 2026-04-26)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`028d9a06` ➡️ `50633843`](https://github.com/nvim-telescope/telescope.nvim/compare/028d9a0695a0cc4cfa893889f8c408ed7ccc8adc...506338434fec5ad19cb1f8d45bf92d66c4917393) <sub>(2026-04-19 to 2026-04-22)<sub/>