### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
     "funky-formatter-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775222241,
-        "narHash": "sha256-aEpTU0uTCdih0rFwNmnzTCUzDK2mHiQrwtKwVp/4YIo=",
+        "lastModified": 1777811754,
+        "narHash": "sha256-4qAmNXzbQhD9SCVYQ2SGrmR9QwynhKnTwGAxkFXYPao=",
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
-        "rev": "9307a67bccb0fc17698211ae05f1f30bf568038b",
+        "rev": "57bcb3b15af93b171b09cf84d84219fbc452543a",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1775957658,
-        "narHash": "sha256-PHunrG0yd3pDw3c1S9w1AXQx5/1nT68M+mjxT53enmM=",
+        "lastModified": 1777365207,
+        "narHash": "sha256-5+JKZD4w80QZxnFv+1OxkFVety8fgmcGVOuxfYouxhI=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "a905eeebc4e63fdc48b5135d3bf8aea5618fb21c",
+        "rev": "131a558e13f9f28b15cd235557150ccb23f89286",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1739121671,
-        "narHash": "sha256-HoZEwncrUnypWxyB+XR0UQDv+tNu1/NbvimxYGb7qu8=",
+        "lastModified": 1777822298,
+        "narHash": "sha256-xSnMYGilRjNHh1G1eOghl8Dr93HsCe3WHHAkchCyW+E=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "ba47d4b4c5ec308718641ba7402c143836f35aa9",
+        "rev": "26b61b1f856ec37cae3cb64f5690adb955f246a1",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1777641297,
+        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1777198644,
-        "narHash": "sha256-w21MFUH+44m3uJKm0LrlXe4etp6TgE6P8tJvy4q+Goc=",
+        "lastModified": 1777577415,
+        "narHash": "sha256-Iox/cnIsgPXB6KYhuy5j2zYHudMCcdQRKWX9DTlIcoo=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "21db1fd40cbcbf1524ae154ab8f394fdf085749a",
+        "rev": "31026a13eefb20681124706a79fc1df6bf11ab27",
         "type": "github"
       },
       "original": {
@@ -221,11 +221,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1775590987,
-        "narHash": "sha256-0H8adz3b0WSW7W1NG+mfJb69/Ag4xK/XCNjqzaP3LsM=",
+        "lastModified": 1777811797,
+        "narHash": "sha256-/k5sEkWcsYRmbxLFjFcmIvnuusSuISx32HH2u8dWudw=",
         "owner": "dkuettel",
         "repo": "ptags.nvim",
-        "rev": "b737c85e0cd5d3f7d1867508015edace194c4717",
+        "rev": "0cde99f2c395968bceea9b0d871b84da600b5f2a",
         "type": "github"
       },
       "original": {
@@ -250,11 +250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773870109,
-        "narHash": "sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4=",
+        "lastModified": 1776659114,
+        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "b6e74f433b02fa4b8a7965ee24680f4867e2926f",
+        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775197701,
-        "narHash": "sha256-W9dcvnvbpZZexKVnDp/8NiNXqy2gnq1FWCD142/Skp8=",
+        "lastModified": 1776715674,
+        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "946e5fb82c3443940c45e5a61686d173e2e21155",
+        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1777221488,
-        "narHash": "sha256-/95BrY/Eiou0BouuCtlGp7NPE5yTjG0uVezxnuzPWZk=",
+        "lastModified": 1777303491,
+        "narHash": "sha256-IEa5lqlAXekQFqjb+Vjv1k+uZY4De19N9am+nBAXGLk=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "6593c19f2ff93057562e41a9ee1b22503b7e5e91",
+        "rev": "7825ce662964e8e1aff926b1244faf52ad6bbdbb",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1776840800,
-        "narHash": "sha256-ekfqqG44cS13FJ0qQKOCl8bftxF8BSRD5v+wZrCAvb8=",
+        "lastModified": 1777725261,
+        "narHash": "sha256-JPwaWFjW4W5ZKAnKEkMnK41JS4omsKYxmRerGMGALDc=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "506338434fec5ad19cb1f8d45bf92d66c4917393",
+        "rev": "ec009610d5d259ec59a6edf0219ef3f7ee4732e5",
         "type": "github"
       },
       "original": {
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775195476,
-        "narHash": "sha256-uaPmLBiYfd6dpTJD8SI6+8Cg0ciUpHc5uN5EbFmd6SE=",
+        "lastModified": 1777463177,
+        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "7fac30f496a7d9853e8c301a8edbfc35af50d418",
+        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/9307a67bccb0fc17698211ae05f1f30bf568038b?narHash=sha256-aEpTU0uTCdih0rFwNmnzTCUzDK2mHiQrwtKwVp/4YIo%3D' (2026-04-03)
  → 'github:dkuettel/funky-formatter.nvim/57bcb3b15af93b171b09cf84d84219fbc452543a?narHash=sha256-4qAmNXzbQhD9SCVYQ2SGrmR9QwynhKnTwGAxkFXYPao%3D' (2026-05-03)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/a905eeebc4e63fdc48b5135d3bf8aea5618fb21c?narHash=sha256-PHunrG0yd3pDw3c1S9w1AXQx5/1nT68M%2BmjxT53enmM%3D' (2026-04-12)
  → 'github:nvim-lualine/lualine.nvim/131a558e13f9f28b15cd235557150ccb23f89286?narHash=sha256-5%2BJKZD4w80QZxnFv%2B1OxkFVety8fgmcGVOuxfYouxhI%3D' (2026-04-28)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/ba47d4b4c5ec308718641ba7402c143836f35aa9?narHash=sha256-HoZEwncrUnypWxyB%2BXR0UQDv%2BtNu1/NbvimxYGb7qu8%3D' (2025-02-09)
  → 'github:EdenEast/nightfox.nvim/26b61b1f856ec37cae3cb64f5690adb955f246a1?narHash=sha256-xSnMYGilRjNHh1G1eOghl8Dr93HsCe3WHHAkchCyW%2BE%3D' (2026-05-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30?narHash=sha256-GMSVw35Q%2B294GlrTUKlx087E31z7KurReQ1YHSKp5iw%3D' (2026-04-23)
  → 'github:nixos/nixpkgs/c6d65881c5624c9cae5ea6cedef24699b0c0a4c0?narHash=sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk%3D' (2026-05-01)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/21db1fd40cbcbf1524ae154ab8f394fdf085749a?narHash=sha256-w21MFUH%2B44m3uJKm0LrlXe4etp6TgE6P8tJvy4q%2BGoc%3D' (2026-04-26)
  → 'github:neovim/nvim-lspconfig/31026a13eefb20681124706a79fc1df6bf11ab27?narHash=sha256-Iox/cnIsgPXB6KYhuy5j2zYHudMCcdQRKWX9DTlIcoo%3D' (2026-04-30)
• Updated input 'ptags-nvim':
    'github:dkuettel/ptags.nvim/b737c85e0cd5d3f7d1867508015edace194c4717?narHash=sha256-0H8adz3b0WSW7W1NG%2BmfJb69/Ag4xK/XCNjqzaP3LsM%3D' (2026-04-07)
  → 'github:dkuettel/ptags.nvim/0cde99f2c395968bceea9b0d871b84da600b5f2a?narHash=sha256-/k5sEkWcsYRmbxLFjFcmIvnuusSuISx32HH2u8dWudw%3D' (2026-05-03)
• Updated input 'ptags-nvim/nixpkgs':
    'github:NixOS/nixpkgs/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e?narHash=sha256-d3Yx83vSrN%2B2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA%3D' (2026-04-01)
  → 'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769?narHash=sha256-ypxFOeDz%2BCqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI%3D' (2026-04-29)
• Updated input 'ptags-nvim/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/b6e74f433b02fa4b8a7965ee24680f4867e2926f?narHash=sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4%3D' (2026-03-18)
  → 'github:pyproject-nix/build-system-pkgs/ffaa2161dd5d63e0e94591f86b54fc239660fb2e?narHash=sha256-qapCOQmR%2B%2ByZSY43dzrp3wCrkOTLpod%2BONtJWBk6iKU%3D' (2026-04-20)
• Updated input 'ptags-nvim/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/946e5fb82c3443940c45e5a61686d173e2e21155?narHash=sha256-W9dcvnvbpZZexKVnDp/8NiNXqy2gnq1FWCD142/Skp8%3D' (2026-04-03)
  → 'github:pyproject-nix/pyproject.nix/69f57f27e52a87c54e28138a75ec741cd46663c9?narHash=sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg%3D' (2026-04-20)
• Updated input 'ptags-nvim/uv2nix':
    'github:pyproject-nix/uv2nix/7fac30f496a7d9853e8c301a8edbfc35af50d418?narHash=sha256-uaPmLBiYfd6dpTJD8SI6%2B8Cg0ciUpHc5uN5EbFmd6SE%3D' (2026-04-03)
  → 'github:pyproject-nix/uv2nix/6c53dcf4d3f63240f57e0b0c826cb15eda61f249?narHash=sha256-1PcD0%2BIZPQXyvmXJ1OYH%2B23sRc9IyOKrUUBYZonVBm8%3D' (2026-04-29)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/6593c19f2ff93057562e41a9ee1b22503b7e5e91?narHash=sha256-/95BrY/Eiou0BouuCtlGp7NPE5yTjG0uVezxnuzPWZk%3D' (2026-04-26)
  → 'github:lima1909/resty.nvim/7825ce662964e8e1aff926b1244faf52ad6bbdbb?narHash=sha256-IEa5lqlAXekQFqjb%2BVjv1k%2BuZY4De19N9am%2BnBAXGLk%3D' (2026-04-27)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/506338434fec5ad19cb1f8d45bf92d66c4917393?narHash=sha256-ekfqqG44cS13FJ0qQKOCl8bftxF8BSRD5v%2BwZrCAvb8%3D' (2026-04-22)
  → 'github:nvim-telescope/telescope.nvim/ec009610d5d259ec59a6edf0219ef3f7ee4732e5?narHash=sha256-JPwaWFjW4W5ZKAnKEkMnK41JS4omsKYxmRerGMGALDc%3D' (2026-05-02)

```

</p></details>

 - Updated input [`funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [`9307a67b` ➡️ `57bcb3b1`](https://github.com/dkuettel/funky-formatter.nvim/compare/9307a67bccb0fc17698211ae05f1f30bf568038b...57bcb3b15af93b171b09cf84d84219fbc452543a) <sub>(2026-04-03 to 2026-05-03)<sub/>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`a905eeeb` ➡️ `131a558e`](https://github.com/nvim-lualine/lualine.nvim/compare/a905eeebc4e63fdc48b5135d3bf8aea5618fb21c...131a558e13f9f28b15cd235557150ccb23f89286) <sub>(2026-04-12 to 2026-04-28)<sub/>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`ba47d4b4` ➡️ `26b61b1f`](https://github.com/EdenEast/nightfox.nvim/compare/ba47d4b4c5ec308718641ba7402c143836f35aa9...26b61b1f856ec37cae3cb64f5690adb955f246a1) <sub>(2025-02-09 to 2026-05-03)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`01fbdeef` ➡️ `c6d65881`](https://github.com/nixos/nixpkgs/compare/01fbdeef22b76df85ea168fbfe1bfd9e63681b30...c6d65881c5624c9cae5ea6cedef24699b0c0a4c0) <sub>(2026-04-23 to 2026-05-01)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`21db1fd4` ➡️ `31026a13`](https://github.com/neovim/nvim-lspconfig/compare/21db1fd40cbcbf1524ae154ab8f394fdf085749a...31026a13eefb20681124706a79fc1df6bf11ab27) <sub>(2026-04-26 to 2026-04-30)<sub/>
 - Updated input [`ptags-nvim`](https://github.com/dkuettel/ptags.nvim): [`b737c85e` ➡️ `0cde99f2`](https://github.com/dkuettel/ptags.nvim/compare/b737c85e0cd5d3f7d1867508015edace194c4717...0cde99f2c395968bceea9b0d871b84da600b5f2a) <sub>(2026-04-07 to 2026-05-03)<sub/>
 - Updated input [`ptags-nvim/nixpkgs`](https://github.com/NixOS/nixpkgs): [`bcd464cc` ➡️ `755f5aa9`](https://github.com/NixOS/nixpkgs/compare/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e...755f5aa91337890c432639c60b6064bb7fe67769) <sub>(2026-04-01 to 2026-04-29)<sub/>
 - Updated input [`ptags-nvim/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [`b6e74f43` ➡️ `ffaa2161`](https://github.com/pyproject-nix/build-system-pkgs/compare/b6e74f433b02fa4b8a7965ee24680f4867e2926f...ffaa2161dd5d63e0e94591f86b54fc239660fb2e) <sub>(2026-03-18 to 2026-04-20)<sub/>
 - Updated input [`ptags-nvim/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [`946e5fb8` ➡️ `69f57f27`](https://github.com/pyproject-nix/pyproject.nix/compare/946e5fb82c3443940c45e5a61686d173e2e21155...69f57f27e52a87c54e28138a75ec741cd46663c9) <sub>(2026-04-03 to 2026-04-20)<sub/>
 - Updated input [`ptags-nvim/uv2nix`](https://github.com/pyproject-nix/uv2nix): [`7fac30f4` ➡️ `6c53dcf4`](https://github.com/pyproject-nix/uv2nix/compare/7fac30f496a7d9853e8c301a8edbfc35af50d418...6c53dcf4d3f63240f57e0b0c826cb15eda61f249) <sub>(2026-04-03 to 2026-04-29)<sub/>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`6593c19f` ➡️ `7825ce66`](https://github.com/lima1909/resty.nvim/compare/6593c19f2ff93057562e41a9ee1b22503b7e5e91...7825ce662964e8e1aff926b1244faf52ad6bbdbb) <sub>(2026-04-26 to 2026-04-27)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`50633843` ➡️ `ec009610`](https://github.com/nvim-telescope/telescope.nvim/compare/506338434fec5ad19cb1f8d45bf92d66c4917393...ec009610d5d259ec59a6edf0219ef3f7ee4732e5) <sub>(2026-04-22 to 2026-05-02)<sub/>