### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777641297,
-        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1777577415,
-        "narHash": "sha256-Iox/cnIsgPXB6KYhuy5j2zYHudMCcdQRKWX9DTlIcoo=",
+        "lastModified": 1778176175,
+        "narHash": "sha256-EEyLO0Mb/wCjBslHHnXcx1k0u9glFGfevZs1pIQxxMU=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "31026a13eefb20681124706a79fc1df6bf11ab27",
+        "rev": "451d4ef9abd4f0f08e379ef0d55d1c391b6125a7",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
     "telescope-fzf-native-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1762521376,
-        "narHash": "sha256-ChEM4jJonAE4qXd/dgTu2mdlpNBj5rEdpA8TgR38oRM=",
+        "lastModified": 1778077831,
+        "narHash": "sha256-FMzAAkS/TgdINK/YuadHXikFcTYtgYeXcEL0jDvWKzk=",
         "owner": "nvim-telescope",
         "repo": "telescope-fzf-native.nvim",
-        "rev": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c",
+        "rev": "b25b749b9db64d375d782094e2b9dce53ad53a40",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1777725261,
-        "narHash": "sha256-JPwaWFjW4W5ZKAnKEkMnK41JS4omsKYxmRerGMGALDc=",
+        "lastModified": 1777881308,
+        "narHash": "sha256-M5cAQe0VxKwiOsLqXmlxNzd8xvLW+J1+Hd31PFmK+S8=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "ec009610d5d259ec59a6edf0219ef3f7ee4732e5",
+        "rev": "f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c6d65881c5624c9cae5ea6cedef24699b0c0a4c0?narHash=sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk%3D' (2026-05-01)
  → 'github:nixos/nixpkgs/b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7?narHash=sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM%3D' (2026-05-08)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/31026a13eefb20681124706a79fc1df6bf11ab27?narHash=sha256-Iox/cnIsgPXB6KYhuy5j2zYHudMCcdQRKWX9DTlIcoo%3D' (2026-04-30)
  → 'github:neovim/nvim-lspconfig/451d4ef9abd4f0f08e379ef0d55d1c391b6125a7?narHash=sha256-EEyLO0Mb/wCjBslHHnXcx1k0u9glFGfevZs1pIQxxMU%3D' (2026-05-07)
• Updated input 'telescope-fzf-native-nvim':
    'github:nvim-telescope/telescope-fzf-native.nvim/6fea601bd2b694c6f2ae08a6c6fab14930c60e2c?narHash=sha256-ChEM4jJonAE4qXd/dgTu2mdlpNBj5rEdpA8TgR38oRM%3D' (2025-11-07)
  → 'github:nvim-telescope/telescope-fzf-native.nvim/b25b749b9db64d375d782094e2b9dce53ad53a40?narHash=sha256-FMzAAkS/TgdINK/YuadHXikFcTYtgYeXcEL0jDvWKzk%3D' (2026-05-06)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/ec009610d5d259ec59a6edf0219ef3f7ee4732e5?narHash=sha256-JPwaWFjW4W5ZKAnKEkMnK41JS4omsKYxmRerGMGALDc%3D' (2026-05-02)
  → 'github:nvim-telescope/telescope.nvim/f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59?narHash=sha256-M5cAQe0VxKwiOsLqXmlxNzd8xvLW%2BJ1%2BHd31PFmK%2BS8%3D' (2026-05-04)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`c6d65881` ➡️ `b3da6560`](https://github.com/nixos/nixpkgs/compare/c6d65881c5624c9cae5ea6cedef24699b0c0a4c0...b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7) <sub>(2026-05-01 to 2026-05-08)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`31026a13` ➡️ `451d4ef9`](https://github.com/neovim/nvim-lspconfig/compare/31026a13eefb20681124706a79fc1df6bf11ab27...451d4ef9abd4f0f08e379ef0d55d1c391b6125a7) <sub>(2026-04-30 to 2026-05-07)<sub/>
 - Updated input [`telescope-fzf-native-nvim`](https://github.com/nvim-telescope/telescope-fzf-native.nvim): [`6fea601b` ➡️ `b25b749b`](https://github.com/nvim-telescope/telescope-fzf-native.nvim/compare/6fea601bd2b694c6f2ae08a6c6fab14930c60e2c...b25b749b9db64d375d782094e2b9dce53ad53a40) <sub>(2025-11-07 to 2026-05-06)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`ec009610` ➡️ `f04ab730`](https://github.com/nvim-telescope/telescope.nvim/compare/ec009610d5d259ec59a6edf0219ef3f7ee4732e5...f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59) <sub>(2026-05-02 to 2026-05-04)<sub/>