### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1778176175,
-        "narHash": "sha256-EEyLO0Mb/wCjBslHHnXcx1k0u9glFGfevZs1pIQxxMU=",
+        "lastModified": 1778941332,
+        "narHash": "sha256-C6+maop+hKjkAocb+7jZ/J6gO/wvDvvWCytETId68ds=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "451d4ef9abd4f0f08e379ef0d55d1c391b6125a7",
+        "rev": "f9349d4d99e7d66403ae8bf4fbd357b154dca7a7",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1777881308,
-        "narHash": "sha256-M5cAQe0VxKwiOsLqXmlxNzd8xvLW+J1+Hd31PFmK+S8=",
+        "lastModified": 1778830862,
+        "narHash": "sha256-+e/ijnuw0Zrj+zcfO2iRusukD4WHrgVC5reOTNk/04o=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59",
+        "rev": "7d324792b7943e4aa16ad007212e6acc6f9fe335",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7?narHash=sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM%3D' (2026-05-08)
  → 'github:nixos/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/451d4ef9abd4f0f08e379ef0d55d1c391b6125a7?narHash=sha256-EEyLO0Mb/wCjBslHHnXcx1k0u9glFGfevZs1pIQxxMU%3D' (2026-05-07)
  → 'github:neovim/nvim-lspconfig/f9349d4d99e7d66403ae8bf4fbd357b154dca7a7?narHash=sha256-C6%2Bmaop%2BhKjkAocb%2B7jZ/J6gO/wvDvvWCytETId68ds%3D' (2026-05-16)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59?narHash=sha256-M5cAQe0VxKwiOsLqXmlxNzd8xvLW%2BJ1%2BHd31PFmK%2BS8%3D' (2026-05-04)
  → 'github:nvim-telescope/telescope.nvim/7d324792b7943e4aa16ad007212e6acc6f9fe335?narHash=sha256-%2Be/ijnuw0Zrj%2BzcfO2iRusukD4WHrgVC5reOTNk/04o%3D' (2026-05-15)
```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`b3da6560` ➡️ `d2339023`](https://github.com/nixos/nixpkgs/compare/b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7...d233902339c02a9c334e7e593de68855ad26c4cb) <sub>(2026-05-08 to 2026-05-15)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`451d4ef9` ➡️ `f9349d4d`](https://github.com/neovim/nvim-lspconfig/compare/451d4ef9abd4f0f08e379ef0d55d1c391b6125a7...f9349d4d99e7d66403ae8bf4fbd357b154dca7a7) <sub>(2026-05-07 to 2026-05-16)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`f04ab730` ➡️ `7d324792`](https://github.com/nvim-telescope/telescope.nvim/compare/f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59...7d324792b7943e4aa16ad007212e6acc6f9fe335) <sub>(2026-05-04 to 2026-05-15)<sub/>