### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1778941332,
-        "narHash": "sha256-C6+maop+hKjkAocb+7jZ/J6gO/wvDvvWCytETId68ds=",
+        "lastModified": 1779439973,
+        "narHash": "sha256-8FuXV6e+/luVWrS+xmh6LyLHcBCIgoSR4z5BInPGi6A=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "f9349d4d99e7d66403ae8bf4fbd357b154dca7a7",
+        "rev": "a4ed4e761c400849e8c9f8bda33e5083f890268c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
  → 'github:nixos/nixpkgs/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456?narHash=sha256-q%2BfF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8%3D' (2026-05-23)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/f9349d4d99e7d66403ae8bf4fbd357b154dca7a7?narHash=sha256-C6%2Bmaop%2BhKjkAocb%2B7jZ/J6gO/wvDvvWCytETId68ds%3D' (2026-05-16)
  → 'github:neovim/nvim-lspconfig/a4ed4e761c400849e8c9f8bda33e5083f890268c?narHash=sha256-8FuXV6e%2B/luVWrS%2Bxmh6LyLHcBCIgoSR4z5BInPGi6A%3D' (2026-05-22)
```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d2339023` ➡️ `3d8f0f3f`](https://github.com/nixos/nixpkgs/compare/d233902339c02a9c334e7e593de68855ad26c4cb...3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456) <sub>(2026-05-15 to 2026-05-23)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`f9349d4d` ➡️ `a4ed4e76`](https://github.com/neovim/nvim-lspconfig/compare/f9349d4d99e7d66403ae8bf4fbd357b154dca7a7...a4ed4e761c400849e8c9f8bda33e5083f890268c) <sub>(2026-05-16 to 2026-05-22)<sub/>