### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1777365207,
-        "narHash": "sha256-5+JKZD4w80QZxnFv+1OxkFVety8fgmcGVOuxfYouxhI=",
+        "lastModified": 1780194559,
+        "narHash": "sha256-6PjGu30Ed4/e/HQ3mIFQuUOxcCiti/71jjlMsjN7EoA=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "131a558e13f9f28b15cd235557150ccb23f89286",
+        "rev": "221ce6b2d999187044529f49da6554a92f740a96",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1780030872,
+        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1779439973,
-        "narHash": "sha256-8FuXV6e+/luVWrS+xmh6LyLHcBCIgoSR4z5BInPGi6A=",
+        "lastModified": 1779988647,
+        "narHash": "sha256-KnZQMIp9qzZitsrwcx9Nty3V5KkszSbWJog/m5opMFg=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a4ed4e761c400849e8c9f8bda33e5083f890268c",
+        "rev": "9573948c38bfabeec353ae7dd7d3ffec4c506a6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/131a558e13f9f28b15cd235557150ccb23f89286?narHash=sha256-5%2BJKZD4w80QZxnFv%2B1OxkFVety8fgmcGVOuxfYouxhI%3D' (2026-04-28)
  → 'github:nvim-lualine/lualine.nvim/221ce6b2d999187044529f49da6554a92f740a96?narHash=sha256-6PjGu30Ed4/e/HQ3mIFQuUOxcCiti/71jjlMsjN7EoA%3D' (2026-05-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456?narHash=sha256-q%2BfF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8%3D' (2026-05-23)
  → 'github:nixos/nixpkgs/e9a7635a57597d9754eccebdfc7045e6c8600e6b?narHash=sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL%2BWNQD0rJfJZQ%3D' (2026-05-29)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a4ed4e761c400849e8c9f8bda33e5083f890268c?narHash=sha256-8FuXV6e%2B/luVWrS%2Bxmh6LyLHcBCIgoSR4z5BInPGi6A%3D' (2026-05-22)
  → 'github:neovim/nvim-lspconfig/9573948c38bfabeec353ae7dd7d3ffec4c506a6b?narHash=sha256-KnZQMIp9qzZitsrwcx9Nty3V5KkszSbWJog/m5opMFg%3D' (2026-05-28)
```

</p></details>

 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`131a558e` ➡️ `221ce6b2`](https://github.com/nvim-lualine/lualine.nvim/compare/131a558e13f9f28b15cd235557150ccb23f89286...221ce6b2d999187044529f49da6554a92f740a96) <sub>(2026-04-28 to 2026-05-31)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3d8f0f3f` ➡️ `e9a7635a`](https://github.com/nixos/nixpkgs/compare/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456...e9a7635a57597d9754eccebdfc7045e6c8600e6b) <sub>(2026-05-23 to 2026-05-29)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a4ed4e76` ➡️ `9573948c`](https://github.com/neovim/nvim-lspconfig/compare/a4ed4e761c400849e8c9f8bda33e5083f890268c...9573948c38bfabeec353ae7dd7d3ffec4c506a6b) <sub>(2026-05-22 to 2026-05-28)<sub/>