### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
     "funky-formatter-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1777811754,
-        "narHash": "sha256-4qAmNXzbQhD9SCVYQ2SGrmR9QwynhKnTwGAxkFXYPao=",
+        "lastModified": 1780520744,
+        "narHash": "sha256-h/lB4k4VjO/4yMBBXCD1sGkE3CBnn4P4BnyD5va9CU8=",
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
-        "rev": "57bcb3b15af93b171b09cf84d84219fbc452543a",
+        "rev": "ebe726d482fa4c71d5ef5f04299b8ec551d8a026",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {
@@ -182,16 +182,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
-        "owner": "dkuettel",
-        "ref": "stable",
+        "owner": "nixos",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1779988647,
-        "narHash": "sha256-KnZQMIp9qzZitsrwcx9Nty3V5KkszSbWJog/m5opMFg=",
+        "lastModified": 1780499151,
+        "narHash": "sha256-RDhwY+C2ZHZPPRe1yvgJqonLcez77dVYvTIttVnFPis=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "9573948c38bfabeec353ae7dd7d3ffec4c506a6b",
+        "rev": "229b79051b380377664edc4cbd534930154921a1",
         "type": "github"
       },
       "original": {
@@ -221,11 +221,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1777811797,
-        "narHash": "sha256-/k5sEkWcsYRmbxLFjFcmIvnuusSuISx32HH2u8dWudw=",
+        "lastModified": 1780520665,
+        "narHash": "sha256-WIlPfooHPorgQwVPjR8EdMLLHwuxCugxLcd46Nqs/zQ=",
         "owner": "dkuettel",
         "repo": "ptags.nvim",
-        "rev": "0cde99f2c395968bceea9b0d871b84da600b5f2a",
+        "rev": "dee62838b412601af22c1f478f114fda2e7a9935",
         "type": "github"
       },
       "original": {
@@ -250,11 +250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776659114,
-        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
+        "lastModified": 1779676664,
+        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
+        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776715674,
-        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
+        "lastModified": 1780416763,
+        "narHash": "sha256-rRK3IFixgsrK6S3e14Xz9HAZm7+kMAIl3oi5zZlcwYI=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
+        "rev": "ad83f1ead0e78e57b188f35cb57298affb06fc5f",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777463177,
-        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
+        "lastModified": 1780418295,
+        "narHash": "sha256-yZVQNvmDx1SFjvlwevywsXWJnieSRqmQr7/fCTMyyd0=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
+        "rev": "0497ccef038da091002be7c05263a7f27820974f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/57bcb3b15af93b171b09cf84d84219fbc452543a?narHash=sha256-4qAmNXzbQhD9SCVYQ2SGrmR9QwynhKnTwGAxkFXYPao%3D' (2026-05-03)
  → 'github:dkuettel/funky-formatter.nvim/ebe726d482fa4c71d5ef5f04299b8ec551d8a026?narHash=sha256-h/lB4k4VjO/4yMBBXCD1sGkE3CBnn4P4BnyD5va9CU8%3D' (2026-06-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e9a7635a57597d9754eccebdfc7045e6c8600e6b?narHash=sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL%2BWNQD0rJfJZQ%3D' (2026-05-29)
  → 'github:nixos/nixpkgs/cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73?narHash=sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1%2Bj%2BMRChI3TL4tAA%3D' (2026-06-06)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/9573948c38bfabeec353ae7dd7d3ffec4c506a6b?narHash=sha256-KnZQMIp9qzZitsrwcx9Nty3V5KkszSbWJog/m5opMFg%3D' (2026-05-28)
  → 'github:neovim/nvim-lspconfig/229b79051b380377664edc4cbd534930154921a1?narHash=sha256-RDhwY%2BC2ZHZPPRe1yvgJqonLcez77dVYvTIttVnFPis%3D' (2026-06-03)
• Updated input 'ptags-nvim':
    'github:dkuettel/ptags.nvim/0cde99f2c395968bceea9b0d871b84da600b5f2a?narHash=sha256-/k5sEkWcsYRmbxLFjFcmIvnuusSuISx32HH2u8dWudw%3D' (2026-05-03)
  → 'github:dkuettel/ptags.nvim/dee62838b412601af22c1f478f114fda2e7a9935?narHash=sha256-WIlPfooHPorgQwVPjR8EdMLLHwuxCugxLcd46Nqs/zQ%3D' (2026-06-03)
• Updated input 'ptags-nvim/nixpkgs':
    'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769?narHash=sha256-ypxFOeDz%2BCqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI%3D' (2026-04-29)
  → 'github:NixOS/nixpkgs/b51242d7d43689db2f3be91bd05d5b24fbb469c4?narHash=sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1%2BN6cArVE%3D' (2026-05-31)
• Updated input 'ptags-nvim/pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/ffaa2161dd5d63e0e94591f86b54fc239660fb2e?narHash=sha256-qapCOQmR%2B%2ByZSY43dzrp3wCrkOTLpod%2BONtJWBk6iKU%3D' (2026-04-20)
  → 'github:pyproject-nix/build-system-pkgs/7bff980f37fc24e09dbc986643719900c139bf12?narHash=sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU%3D' (2026-05-25)
• Updated input 'ptags-nvim/pyproject-nix':
    'github:pyproject-nix/pyproject.nix/69f57f27e52a87c54e28138a75ec741cd46663c9?narHash=sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg%3D' (2026-04-20)
  → 'github:pyproject-nix/pyproject.nix/ad83f1ead0e78e57b188f35cb57298affb06fc5f?narHash=sha256-rRK3IFixgsrK6S3e14Xz9HAZm7%2BkMAIl3oi5zZlcwYI%3D' (2026-06-02)
• Updated input 'ptags-nvim/uv2nix':
    'github:pyproject-nix/uv2nix/6c53dcf4d3f63240f57e0b0c826cb15eda61f249?narHash=sha256-1PcD0%2BIZPQXyvmXJ1OYH%2B23sRc9IyOKrUUBYZonVBm8%3D' (2026-04-29)
  → 'github:pyproject-nix/uv2nix/0497ccef038da091002be7c05263a7f27820974f?narHash=sha256-yZVQNvmDx1SFjvlwevywsXWJnieSRqmQr7/fCTMyyd0%3D' (2026-06-02)
```

</p></details>

 - Updated input [`funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [`57bcb3b1` ➡️ `ebe726d4`](https://github.com/dkuettel/funky-formatter.nvim/compare/57bcb3b15af93b171b09cf84d84219fbc452543a...ebe726d482fa4c71d5ef5f04299b8ec551d8a026) <sub>(2026-05-03 to 2026-06-03)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e9a7635a` ➡️ `cbb5cf35`](https://github.com/nixos/nixpkgs/compare/e9a7635a57597d9754eccebdfc7045e6c8600e6b...cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73) <sub>(2026-05-29 to 2026-06-06)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`9573948c` ➡️ `229b7905`](https://github.com/neovim/nvim-lspconfig/compare/9573948c38bfabeec353ae7dd7d3ffec4c506a6b...229b79051b380377664edc4cbd534930154921a1) <sub>(2026-05-28 to 2026-06-03)<sub/>
 - Updated input [`ptags-nvim`](https://github.com/dkuettel/ptags.nvim): [`0cde99f2` ➡️ `dee62838`](https://github.com/dkuettel/ptags.nvim/compare/0cde99f2c395968bceea9b0d871b84da600b5f2a...dee62838b412601af22c1f478f114fda2e7a9935) <sub>(2026-05-03 to 2026-06-03)<sub/>
 - Updated input [`ptags-nvim/nixpkgs`](https://github.com/NixOS/nixpkgs): [`755f5aa9` ➡️ `b51242d7`](https://github.com/NixOS/nixpkgs/compare/755f5aa91337890c432639c60b6064bb7fe67769...b51242d7d43689db2f3be91bd05d5b24fbb469c4) <sub>(2026-04-29 to 2026-05-31)<sub/>
 - Updated input [`ptags-nvim/pyproject-build-systems`](https://github.com/pyproject-nix/build-system-pkgs): [`ffaa2161` ➡️ `7bff980f`](https://github.com/pyproject-nix/build-system-pkgs/compare/ffaa2161dd5d63e0e94591f86b54fc239660fb2e...7bff980f37fc24e09dbc986643719900c139bf12) <sub>(2026-04-20 to 2026-05-25)<sub/>
 - Updated input [`ptags-nvim/pyproject-nix`](https://github.com/pyproject-nix/pyproject.nix): [`69f57f27` ➡️ `ad83f1ea`](https://github.com/pyproject-nix/pyproject.nix/compare/69f57f27e52a87c54e28138a75ec741cd46663c9...ad83f1ead0e78e57b188f35cb57298affb06fc5f) <sub>(2026-04-20 to 2026-06-02)<sub/>
 - Updated input [`ptags-nvim/uv2nix`](https://github.com/pyproject-nix/uv2nix): [`6c53dcf4` ➡️ `0497ccef`](https://github.com/pyproject-nix/uv2nix/compare/6c53dcf4d3f63240f57e0b0c826cb15eda61f249...0497ccef038da091002be7c05263a7f27820974f) <sub>(2026-04-29 to 2026-06-02)<sub/>