### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1771362711,
-        "narHash": "sha256-ruEJ0kP91ZuPXClBm3E1BIViEc3uX7p8e1ebHNuf1uI=",
+        "lastModified": 1781037950,
+        "narHash": "sha256-QbfTy3dzZ5XWzB69S9y8xXBcRp3w0aDIXB1tKgLqF7U=",
         "owner": "dkuettel",
         "repo": "lavish-layouts.nvim",
-        "rev": "242938b6d6735e92bb300b7e86dd1e2b597fe524",
+        "rev": "f53319886dd1769b47aa6fb0c9297844c95d8382",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780747962,
-        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
+        "lastModified": 1781359544,
+        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
+        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1780499151,
-        "narHash": "sha256-RDhwY+C2ZHZPPRe1yvgJqonLcez77dVYvTIttVnFPis=",
+        "lastModified": 1781296998,
+        "narHash": "sha256-uFG6LfYGuu5X9gLzCLbIpQd6af+RUoF8aED4Tp7cOcw=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "229b79051b380377664edc4cbd534930154921a1",
+        "rev": "a683e0ddf0cf64c6cd689e18ffb480ade3c162b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'lavish-layouts-nvim':
    'github:dkuettel/lavish-layouts.nvim/242938b6d6735e92bb300b7e86dd1e2b597fe524?narHash=sha256-ruEJ0kP91ZuPXClBm3E1BIViEc3uX7p8e1ebHNuf1uI%3D' (2026-02-17)
  → 'github:dkuettel/lavish-layouts.nvim/f53319886dd1769b47aa6fb0c9297844c95d8382?narHash=sha256-QbfTy3dzZ5XWzB69S9y8xXBcRp3w0aDIXB1tKgLqF7U%3D' (2026-06-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73?narHash=sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1%2Bj%2BMRChI3TL4tAA%3D' (2026-06-06)
  → 'github:nixos/nixpkgs/9f11f828c213641c2369a9f1fa31fe31557e3156?narHash=sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE%3D' (2026-06-13)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/229b79051b380377664edc4cbd534930154921a1?narHash=sha256-RDhwY%2BC2ZHZPPRe1yvgJqonLcez77dVYvTIttVnFPis%3D' (2026-06-03)
  → 'github:neovim/nvim-lspconfig/a683e0ddf0cf64c6cd689e18ffb480ade3c162b7?narHash=sha256-uFG6LfYGuu5X9gLzCLbIpQd6af%2BRUoF8aED4Tp7cOcw%3D' (2026-06-12)
```

</p></details>

 - Updated input [`lavish-layouts-nvim`](https://github.com/dkuettel/lavish-layouts.nvim): [`242938b6` ➡️ `f5331988`](https://github.com/dkuettel/lavish-layouts.nvim/compare/242938b6d6735e92bb300b7e86dd1e2b597fe524...f53319886dd1769b47aa6fb0c9297844c95d8382) <sub>(2026-02-17 to 2026-06-09)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`cbb5cf35` ➡️ `9f11f828`](https://github.com/nixos/nixpkgs/compare/cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73...9f11f828c213641c2369a9f1fa31fe31557e3156) <sub>(2026-06-06 to 2026-06-13)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`229b7905` ➡️ `a683e0dd`](https://github.com/neovim/nvim-lspconfig/compare/229b79051b380377664edc4cbd534930154921a1...a683e0ddf0cf64c6cd689e18ffb480ade3c162b7) <sub>(2026-06-03 to 2026-06-12)<sub/>