### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781359544,
-        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1781296998,
-        "narHash": "sha256-uFG6LfYGuu5X9gLzCLbIpQd6af+RUoF8aED4Tp7cOcw=",
+        "lastModified": 1781881223,
+        "narHash": "sha256-d8d9Hz3xA/J+E0gBRlnfCAFTwmDJE12AWw0n3TrcelU=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a683e0ddf0cf64c6cd689e18ffb480ade3c162b7",
+        "rev": "bfcc0171a43f22afa61d927ffe9fcb6cb85dc99e",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1778830862,
-        "narHash": "sha256-+e/ijnuw0Zrj+zcfO2iRusukD4WHrgVC5reOTNk/04o=",
+        "lastModified": 1781624647,
+        "narHash": "sha256-iFHYx+5Rf3ol7CjVLjqVu+VNjdGfeC8V8nS/1THO+cQ=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "7d324792b7943e4aa16ad007212e6acc6f9fe335",
+        "rev": "9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9f11f828c213641c2369a9f1fa31fe31557e3156?narHash=sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE%3D' (2026-06-13)
  → 'github:nixos/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158?narHash=sha256-rxO%2Buc/KFbSJp%2BpgyXRuAX6QlG9hJdnt0BXpEQRXY%2BU%3D' (2026-06-16)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a683e0ddf0cf64c6cd689e18ffb480ade3c162b7?narHash=sha256-uFG6LfYGuu5X9gLzCLbIpQd6af%2BRUoF8aED4Tp7cOcw%3D' (2026-06-12)
  → 'github:neovim/nvim-lspconfig/bfcc0171a43f22afa61d927ffe9fcb6cb85dc99e?narHash=sha256-d8d9Hz3xA/J%2BE0gBRlnfCAFTwmDJE12AWw0n3TrcelU%3D' (2026-06-19)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/7d324792b7943e4aa16ad007212e6acc6f9fe335?narHash=sha256-%2Be/ijnuw0Zrj%2BzcfO2iRusukD4WHrgVC5reOTNk/04o%3D' (2026-05-15)
  → 'github:nvim-telescope/telescope.nvim/9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc?narHash=sha256-iFHYx%2B5Rf3ol7CjVLjqVu%2BVNjdGfeC8V8nS/1THO%2BcQ%3D' (2026-06-16)
```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`9f11f828` ➡️ `3e41b24a`](https://github.com/nixos/nixpkgs/compare/9f11f828c213641c2369a9f1fa31fe31557e3156...3e41b24abd260e8f71dbe2f5737d24122f972158) <sub>(2026-06-13 to 2026-06-16)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a683e0dd` ➡️ `bfcc0171`](https://github.com/neovim/nvim-lspconfig/compare/a683e0ddf0cf64c6cd689e18ffb480ade3c162b7...bfcc0171a43f22afa61d927ffe9fcb6cb85dc99e) <sub>(2026-06-12 to 2026-06-19)<sub/>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`7d324792` ➡️ `9377230a`](https://github.com/nvim-telescope/telescope.nvim/compare/7d324792b7943e4aa16ad007212e6acc6f9fe335...9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc) <sub>(2026-05-15 to 2026-06-16)<sub/>