### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783247743,
-        "narHash": "sha256-9b2xGt5CAd6WriPJOZs/EYXq9fGVCeoisYo1P3nhL2Y=",
+        "lastModified": 1783816212,
+        "narHash": "sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c4013e501c048ae7c4a8940c92837636042bf6c3",
+        "rev": "3b32825de172d0bc85664f495edb096b10862524",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1783160942,
-        "narHash": "sha256-nBUh7slBfsXAaJ0xYfvD/j+TfBxkETGqq12DtHlj2d0=",
+        "lastModified": 1783882242,
+        "narHash": "sha256-VSrQgki5tR99EMBGF3bO/SbaNzGHNFcOelqSaq4RQAg=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "d224a1920728ba129880efc700d4a0180ac4ecbb",
+        "rev": "2c227d59589957fa4404b7de5f61d72c0a78a62d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c4013e501c048ae7c4a8940c92837636042bf6c3?narHash=sha256-9b2xGt5CAd6WriPJOZs/EYXq9fGVCeoisYo1P3nhL2Y%3D' (2026-07-05)
  → 'github:nixos/nixpkgs/3b32825de172d0bc85664f495edb096b10862524?narHash=sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150%3D' (2026-07-12)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/d224a1920728ba129880efc700d4a0180ac4ecbb?narHash=sha256-nBUh7slBfsXAaJ0xYfvD/j%2BTfBxkETGqq12DtHlj2d0%3D' (2026-07-04)
  → 'github:neovim/nvim-lspconfig/2c227d59589957fa4404b7de5f61d72c0a78a62d?narHash=sha256-VSrQgki5tR99EMBGF3bO/SbaNzGHNFcOelqSaq4RQAg%3D' (2026-07-12)
```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`c4013e50` ➡️ `3b32825d`](https://github.com/nixos/nixpkgs/compare/c4013e501c048ae7c4a8940c92837636042bf6c3...3b32825de172d0bc85664f495edb096b10862524) <sub>(2026-07-05 to 2026-07-12)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`d224a192` ➡️ `2c227d59`](https://github.com/neovim/nvim-lspconfig/compare/d224a1920728ba129880efc700d4a0180ac4ecbb...2c227d59589957fa4404b7de5f61d72c0a78a62d) <sub>(2026-07-04 to 2026-07-12)<sub/>