### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     "lavish-layouts-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1784736379,
-        "narHash": "sha256-ieZqtU/iueS1lRpEYhvvBQiEwZE2m6HF7TzA1cc+pOc=",
+        "lastModified": 1785150153,
+        "narHash": "sha256-5RAta+82lsQX9XABBzgMgXlH/J8XRGoRlyzSyMMcV7g=",
         "owner": "dkuettel",
         "repo": "lavish-layouts.nvim",
-        "rev": "920b1bb6a5bd7e3671a545ef94082edec3451351",
+        "rev": "83eea7e6060db3bef27924381b9bbe61bb728641",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784963784,
-        "narHash": "sha256-IZAjgNI19TdwYus6QUIMvU0cw0vWVb/5oYwpyxQXL1E=",
+        "lastModified": 1785602060,
+        "narHash": "sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "38affae6a5768f9b61f81355c7558ee971b2afb1",
+        "rev": "a5cbcfe954791221bfffe2307f7d1a1bf61a871e",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1785061322,
-        "narHash": "sha256-DP6osN9M8wTYqIAmTX6R+wzoSV3BhFonDjPZd3Kv0y4=",
+        "lastModified": 1785578863,
+        "narHash": "sha256-wQI5ZcMjC57y+o2a2pqr2e9d7FAkgDQfXo9ILny3FqM=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "7ab79bb1b57160a537f427ac8a6026102f12b701",
+        "rev": "1c0d8f70dbc8827263eedc3cf7021ceba0f68689",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'lavish-layouts-nvim':
    'github:dkuettel/lavish-layouts.nvim/920b1bb6a5bd7e3671a545ef94082edec3451351?narHash=sha256-ieZqtU/iueS1lRpEYhvvBQiEwZE2m6HF7TzA1cc%2BpOc%3D' (2026-07-22)
  → 'github:dkuettel/lavish-layouts.nvim/83eea7e6060db3bef27924381b9bbe61bb728641?narHash=sha256-5RAta%2B82lsQX9XABBzgMgXlH/J8XRGoRlyzSyMMcV7g%3D' (2026-07-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/38affae6a5768f9b61f81355c7558ee971b2afb1?narHash=sha256-IZAjgNI19TdwYus6QUIMvU0cw0vWVb/5oYwpyxQXL1E%3D' (2026-07-25)
  → 'github:nixos/nixpkgs/a5cbcfe954791221bfffe2307f7d1a1bf61a871e?narHash=sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4%3D' (2026-08-01)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/7ab79bb1b57160a537f427ac8a6026102f12b701?narHash=sha256-DP6osN9M8wTYqIAmTX6R%2BwzoSV3BhFonDjPZd3Kv0y4%3D' (2026-07-26)
  → 'github:neovim/nvim-lspconfig/1c0d8f70dbc8827263eedc3cf7021ceba0f68689?narHash=sha256-wQI5ZcMjC57y%2Bo2a2pqr2e9d7FAkgDQfXo9ILny3FqM%3D' (2026-08-01)
```

</p></details>

 - Updated input [`lavish-layouts-nvim`](https://github.com/dkuettel/lavish-layouts.nvim): [`920b1bb6` ➡️ `83eea7e6`](https://github.com/dkuettel/lavish-layouts.nvim/compare/920b1bb6a5bd7e3671a545ef94082edec3451351...83eea7e6060db3bef27924381b9bbe61bb728641) <sub>(2026-07-22 to 2026-07-27)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`38affae6` ➡️ `a5cbcfe9`](https://github.com/nixos/nixpkgs/compare/38affae6a5768f9b61f81355c7558ee971b2afb1...a5cbcfe954791221bfffe2307f7d1a1bf61a871e) <sub>(2026-07-25 to 2026-08-01)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`7ab79bb1` ➡️ `1c0d8f70`](https://github.com/neovim/nvim-lspconfig/compare/7ab79bb1b57160a537f427ac8a6026102f12b701...1c0d8f70dbc8827263eedc3cf7021ceba0f68689) <sub>(2026-07-26 to 2026-08-01)<sub/>