### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     "funky-formatter-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1783107512,
-        "narHash": "sha256-lof/vOcnAj3laMNA9pLjhl97YKZuiAXMtFw3bdFYrWA=",
+        "lastModified": 1786053867,
+        "narHash": "sha256-3zcrE+nYS2tW8rkWBW2vaiEoilonAtHnFWaEciNG3LE=",
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
-        "rev": "7d73d2184d9fad961a60c72e736604f037109182",
+        "rev": "cf1abbaad1ec5ab319386fa7ec96b34f7d39bb25",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785602060,
-        "narHash": "sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4=",
+        "lastModified": 1785975029,
+        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a5cbcfe954791221bfffe2307f7d1a1bf61a871e",
+        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1785578863,
-        "narHash": "sha256-wQI5ZcMjC57y+o2a2pqr2e9d7FAkgDQfXo9ILny3FqM=",
+        "lastModified": 1785869536,
+        "narHash": "sha256-4+AaIVi2XiZrX8ug9l7ExMvCZtRk7ctnk4cdacoF+eo=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "1c0d8f70dbc8827263eedc3cf7021ceba0f68689",
+        "rev": "43ed3797b266e1ee8d222e491379ad471c9d3146",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'funky-formatter-nvim':
    'github:dkuettel/funky-formatter.nvim/7d73d2184d9fad961a60c72e736604f037109182?narHash=sha256-lof/vOcnAj3laMNA9pLjhl97YKZuiAXMtFw3bdFYrWA%3D' (2026-07-03)
  → 'github:dkuettel/funky-formatter.nvim/cf1abbaad1ec5ab319386fa7ec96b34f7d39bb25?narHash=sha256-3zcrE%2BnYS2tW8rkWBW2vaiEoilonAtHnFWaEciNG3LE%3D' (2026-08-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a5cbcfe954791221bfffe2307f7d1a1bf61a871e?narHash=sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4%3D' (2026-08-01)
  → 'github:nixos/nixpkgs/70ce234312134a463ba7728e94da2486a1d237ac?narHash=sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU%3D' (2026-08-06)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/1c0d8f70dbc8827263eedc3cf7021ceba0f68689?narHash=sha256-wQI5ZcMjC57y%2Bo2a2pqr2e9d7FAkgDQfXo9ILny3FqM%3D' (2026-08-01)
  → 'github:neovim/nvim-lspconfig/43ed3797b266e1ee8d222e491379ad471c9d3146?narHash=sha256-4%2BAaIVi2XiZrX8ug9l7ExMvCZtRk7ctnk4cdacoF%2Beo%3D' (2026-08-04)
```

</p></details>

 - Updated input [`funky-formatter-nvim`](https://github.com/dkuettel/funky-formatter.nvim): [`7d73d218` ➡️ `cf1abbaa`](https://github.com/dkuettel/funky-formatter.nvim/compare/7d73d2184d9fad961a60c72e736604f037109182...cf1abbaad1ec5ab319386fa7ec96b34f7d39bb25) <sub>(2026-07-03 to 2026-08-06)<sub/>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a5cbcfe9` ➡️ `70ce2343`](https://github.com/nixos/nixpkgs/compare/a5cbcfe954791221bfffe2307f7d1a1bf61a871e...70ce234312134a463ba7728e94da2486a1d237ac) <sub>(2026-08-01 to 2026-08-06)<sub/>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`1c0d8f70` ➡️ `43ed3797`](https://github.com/neovim/nvim-lspconfig/compare/1c0d8f70dbc8827263eedc3cf7021ceba0f68689...43ed3797b266e1ee8d222e491379ad471c9d3146) <sub>(2026-08-01 to 2026-08-04)<sub/>